### PR TITLE
Builder UI

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,7 +22,7 @@
         "@radix-ui/react-label": "2.1.1",
         "@radix-ui/react-menubar": "1.1.4",
         "@radix-ui/react-navigation-menu": "1.2.3",
-        "@radix-ui/react-popover": "1.1.4",
+        "@radix-ui/react-popover": "^1.1.4",
         "@radix-ui/react-progress": "1.1.1",
         "@radix-ui/react-radio-group": "1.2.2",
         "@radix-ui/react-scroll-area": "1.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "@radix-ui/react-label": "2.1.1",
     "@radix-ui/react-menubar": "1.1.4",
     "@radix-ui/react-navigation-menu": "1.2.3",
-    "@radix-ui/react-popover": "1.1.4",
+    "@radix-ui/react-popover": "^1.1.4",
     "@radix-ui/react-progress": "1.1.1",
     "@radix-ui/react-radio-group": "1.2.2",
     "@radix-ui/react-scroll-area": "1.2.2",

--- a/frontend/src/app/projects/[id]/page.tsx
+++ b/frontend/src/app/projects/[id]/page.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import { useParams } from "next/navigation"
+import { useState } from "react"
+import { ChatInterface } from "@/components/chat-interface"
+import { Canvas } from "@/components/canvas"
+
+export default function ProjectPage() {
+  const params = useParams()
+  const projectId = params.id as string
+
+  // TODO: In future, fetch project data based on projectId
+  // For now, we'll use hardcoded data
+  
+  return (
+    <div className="flex h-screen bg-gray-50">
+      {/* Left side - Chat Interface */}
+      <div className="w-80 border-r border-gray-200 bg-white">
+        <ChatInterface projectId={projectId} />
+      </div>
+      
+      {/* Right side - Canvas */}
+      <div className="flex-1">
+        <Canvas projectId={projectId} />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/projects/[id]/page.tsx
+++ b/frontend/src/app/projects/[id]/page.tsx
@@ -15,7 +15,7 @@ export default function ProjectPage() {
   return (
     <div className="flex h-screen bg-gray-50">
       {/* Left side - Chat Interface */}
-      <div className="w-80 border-r border-gray-200 bg-white">
+      <div className="w-[480px] border-r border-gray-200 bg-white">
         <ChatInterface projectId={projectId} />
       </div>
       

--- a/frontend/src/components/AIAssistantUI.jsx
+++ b/frontend/src/components/AIAssistantUI.jsx
@@ -1,0 +1,311 @@
+"use client"
+
+import React, { useEffect, useMemo, useRef, useState } from "react"
+import { Calendar, LayoutGrid, MoreHorizontal } from "lucide-react"
+import Sidebar from "./Sidebar"
+import Header from "./Header"
+import ChatPane from "./ChatPane"
+import GhostIconButton from "./GhostIconButton"
+import ThemeToggle from "./ThemeToggle"
+import { INITIAL_CONVERSATIONS, INITIAL_TEMPLATES, INITIAL_FOLDERS } from "./mockData"
+
+export default function AIAssistantUI() {
+  const [theme, setTheme] = useState(() => {
+    const saved = typeof window !== "undefined" && localStorage.getItem("theme")
+    if (saved) return saved
+    if (typeof window !== "undefined" && window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches)
+      return "dark"
+    return "light"
+  })
+
+  useEffect(() => {
+    try {
+      if (theme === "dark") document.documentElement.classList.add("dark")
+      else document.documentElement.classList.remove("dark")
+      document.documentElement.setAttribute("data-theme", theme)
+      document.documentElement.style.colorScheme = theme
+      localStorage.setItem("theme", theme)
+    } catch {}
+  }, [theme])
+
+  useEffect(() => {
+    try {
+      const media = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)")
+      if (!media) return
+      const listener = (e) => {
+        const saved = localStorage.getItem("theme")
+        if (!saved) setTheme(e.matches ? "dark" : "light")
+      }
+      media.addEventListener("change", listener)
+      return () => media.removeEventListener("change", listener)
+    } catch {}
+  }, [])
+
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+  const [collapsed, setCollapsed] = useState(() => {
+    try {
+      const raw = localStorage.getItem("sidebar-collapsed")
+      return raw ? JSON.parse(raw) : { pinned: true, recent: false, folders: true, templates: true }
+    } catch {
+      return { pinned: true, recent: false, folders: true, templates: true }
+    }
+  })
+  useEffect(() => {
+    try {
+      localStorage.setItem("sidebar-collapsed", JSON.stringify(collapsed))
+    } catch {}
+  }, [collapsed])
+
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
+    try {
+      const saved = localStorage.getItem("sidebar-collapsed-state")
+      return saved ? JSON.parse(saved) : false
+    } catch {
+      return false
+    }
+  })
+
+  useEffect(() => {
+    try {
+      localStorage.setItem("sidebar-collapsed-state", JSON.stringify(sidebarCollapsed))
+    } catch {}
+  }, [sidebarCollapsed])
+
+  const [conversations, setConversations] = useState(INITIAL_CONVERSATIONS)
+  const [selectedId, setSelectedId] = useState(null)
+  const [templates, setTemplates] = useState(INITIAL_TEMPLATES)
+  const [folders, setFolders] = useState(INITIAL_FOLDERS)
+
+  const [query, setQuery] = useState("")
+  const searchRef = useRef(null)
+
+  const [isThinking, setIsThinking] = useState(false)
+  const [thinkingConvId, setThinkingConvId] = useState(null)
+
+  useEffect(() => {
+    const onKey = (e) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "n") {
+        e.preventDefault()
+        createNewChat()
+      }
+      if (!e.metaKey && !e.ctrlKey && e.key === "/") {
+        const tag = document.activeElement?.tagName?.toLowerCase()
+        if (tag !== "input" && tag !== "textarea") {
+          e.preventDefault()
+          searchRef.current?.focus()
+        }
+      }
+      if (e.key === "Escape" && sidebarOpen) setSidebarOpen(false)
+    }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [sidebarOpen, conversations])
+
+  useEffect(() => {
+    if (!selectedId && conversations.length > 0) {
+      createNewChat()
+    }
+  }, [])
+
+  const filtered = useMemo(() => {
+    if (!query.trim()) return conversations
+    const q = query.toLowerCase()
+    return conversations.filter((c) => c.title.toLowerCase().includes(q) || c.preview.toLowerCase().includes(q))
+  }, [conversations, query])
+
+  const pinned = filtered.filter((c) => c.pinned).sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1))
+
+  const recent = filtered
+    .filter((c) => !c.pinned)
+    .sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1))
+    .slice(0, 10)
+
+  const folderCounts = React.useMemo(() => {
+    const map = Object.fromEntries(folders.map((f) => [f.name, 0]))
+    for (const c of conversations) if (map[c.folder] != null) map[c.folder] += 1
+    return map
+  }, [conversations, folders])
+
+  function togglePin(id) {
+    setConversations((prev) => prev.map((c) => (c.id === id ? { ...c, pinned: !c.pinned } : c)))
+  }
+
+  function createNewChat() {
+    const id = Math.random().toString(36).slice(2)
+    const item = {
+      id,
+      title: "New Chat",
+      updatedAt: new Date().toISOString(),
+      messageCount: 0,
+      preview: "Say hello to start...",
+      pinned: false,
+      folder: "Work Projects",
+      messages: [], // Ensure messages array is empty for new chats
+    }
+    setConversations((prev) => [item, ...prev])
+    setSelectedId(id)
+    setSidebarOpen(false)
+  }
+
+  function createFolder() {
+    const name = prompt("Folder name")
+    if (!name) return
+    if (folders.some((f) => f.name.toLowerCase() === name.toLowerCase())) return alert("Folder already exists.")
+    setFolders((prev) => [...prev, { id: Math.random().toString(36).slice(2), name }])
+  }
+
+  function sendMessage(convId, content) {
+    if (!content.trim()) return
+    const now = new Date().toISOString()
+    const userMsg = { id: Math.random().toString(36).slice(2), role: "user", content, createdAt: now }
+
+    setConversations((prev) =>
+      prev.map((c) => {
+        if (c.id !== convId) return c
+        const msgs = [...(c.messages || []), userMsg]
+        return {
+          ...c,
+          messages: msgs,
+          updatedAt: now,
+          messageCount: msgs.length,
+          preview: content.slice(0, 80),
+        }
+      }),
+    )
+
+    setIsThinking(true)
+    setThinkingConvId(convId)
+
+    const currentConvId = convId
+    setTimeout(() => {
+      // Always clear thinking state and generate response for this specific conversation
+      setIsThinking(false)
+      setThinkingConvId(null)
+      setConversations((prev) =>
+        prev.map((c) => {
+          if (c.id !== currentConvId) return c
+          const ack = `Got it — I'll help with that.`
+          const asstMsg = {
+            id: Math.random().toString(36).slice(2),
+            role: "assistant",
+            content: ack,
+            createdAt: new Date().toISOString(),
+          }
+          const msgs = [...(c.messages || []), asstMsg]
+          return {
+            ...c,
+            messages: msgs,
+            updatedAt: new Date().toISOString(),
+            messageCount: msgs.length,
+            preview: asstMsg.content.slice(0, 80),
+          }
+        }),
+      )
+    }, 2000)
+  }
+
+  function editMessage(convId, messageId, newContent) {
+    const now = new Date().toISOString()
+    setConversations((prev) =>
+      prev.map((c) => {
+        if (c.id !== convId) return c
+        const msgs = (c.messages || []).map((m) =>
+          m.id === messageId ? { ...m, content: newContent, editedAt: now } : m,
+        )
+        return {
+          ...c,
+          messages: msgs,
+          preview: msgs[msgs.length - 1]?.content?.slice(0, 80) || c.preview,
+        }
+      }),
+    )
+  }
+
+  function resendMessage(convId, messageId) {
+    const conv = conversations.find((c) => c.id === convId)
+    const msg = conv?.messages?.find((m) => m.id === messageId)
+    if (!msg) return
+    sendMessage(convId, msg.content)
+  }
+
+  function pauseThinking() {
+    setIsThinking(false)
+    setThinkingConvId(null)
+  }
+
+  function handleUseTemplate(template) {
+    // This will be passed down to the Composer component
+    // The Composer will handle inserting the template content
+    if (composerRef.current) {
+      composerRef.current.insertTemplate(template.content)
+    }
+  }
+
+  const composerRef = useRef(null)
+
+  const selected = conversations.find((c) => c.id === selectedId) || null
+
+  return (
+    <div className="h-screen w-full bg-zinc-50 text-zinc-900 dark:bg-zinc-950 dark:text-zinc-100">
+      <div className="md:hidden sticky top-0 z-40 flex items-center gap-2 border-b border-zinc-200/60 bg-white/80 px-3 py-2 backdrop-blur dark:border-zinc-800 dark:bg-zinc-900/70">
+        <div className="ml-1 flex items-center gap-2 text-sm font-semibold tracking-tight">
+          <span className="inline-flex h-4 w-4 items-center justify-center">✱</span> AI Assistant
+        </div>
+        <div className="ml-auto flex items-center gap-2">
+          <GhostIconButton label="Schedule">
+            <Calendar className="h-4 w-4" />
+          </GhostIconButton>
+          <GhostIconButton label="Apps">
+            <LayoutGrid className="h-4 w-4" />
+          </GhostIconButton>
+          <GhostIconButton label="More">
+            <MoreHorizontal className="h-4 w-4" />
+          </GhostIconButton>
+          <ThemeToggle theme={theme} setTheme={setTheme} />
+        </div>
+      </div>
+
+      <div className="mx-auto flex h-[calc(100vh-0px)] max-w-[1400px]">
+        <Sidebar
+          open={sidebarOpen}
+          onClose={() => setSidebarOpen(false)}
+          theme={theme}
+          setTheme={setTheme}
+          collapsed={collapsed}
+          setCollapsed={setCollapsed}
+          sidebarCollapsed={sidebarCollapsed}
+          setSidebarCollapsed={setSidebarCollapsed}
+          conversations={conversations}
+          pinned={pinned}
+          recent={recent}
+          folders={folders}
+          folderCounts={folderCounts}
+          selectedId={selectedId}
+          onSelect={(id) => setSelectedId(id)}
+          togglePin={togglePin}
+          query={query}
+          setQuery={setQuery}
+          searchRef={searchRef}
+          createFolder={createFolder}
+          createNewChat={createNewChat}
+          templates={templates}
+          setTemplates={setTemplates}
+          onUseTemplate={handleUseTemplate}
+        />
+
+        <main className="relative flex min-w-0 flex-1 flex-col">
+          <Header createNewChat={createNewChat} sidebarCollapsed={sidebarCollapsed} setSidebarOpen={setSidebarOpen} />
+          <ChatPane
+            ref={composerRef}
+            conversation={selected}
+            onSend={(content) => selected && sendMessage(selected.id, content)}
+            onEditMessage={(messageId, newContent) => selected && editMessage(selected.id, messageId, newContent)}
+            onResendMessage={(messageId) => selected && resendMessage(selected.id, messageId)}
+            isThinking={isThinking && thinkingConvId === selected?.id}
+            onPauseThinking={pauseThinking}
+          />
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ChatPane.jsx
+++ b/frontend/src/components/ChatPane.jsx
@@ -1,0 +1,172 @@
+"use client"
+
+import { useState, forwardRef, useImperativeHandle, useRef } from "react"
+import { Pencil, RefreshCw, Check, X, Square } from "lucide-react"
+import Message from "./Message"
+import Composer from "./Composer"
+import { cls, timeAgo } from "./utils"
+
+function ThinkingMessage({ onPause }) {
+  return (
+    <Message role="assistant">
+      <div className="flex items-center gap-3">
+        <div className="flex items-center gap-1">
+          <div className="h-2 w-2 animate-bounce rounded-full bg-zinc-400 [animation-delay:-0.3s]"></div>
+          <div className="h-2 w-2 animate-bounce rounded-full bg-zinc-400 [animation-delay:-0.15s]"></div>
+          <div className="h-2 w-2 animate-bounce rounded-full bg-zinc-400"></div>
+        </div>
+        <span className="text-sm text-zinc-500">AI is thinking...</span>
+        <button
+          onClick={onPause}
+          className="ml-auto inline-flex items-center gap-1 rounded-full border border-zinc-300 px-2 py-1 text-xs text-zinc-600 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-400 dark:hover:bg-zinc-800"
+        >
+          <Square className="h-3 w-3" /> Pause
+        </button>
+      </div>
+    </Message>
+  )
+}
+
+const ChatPane = forwardRef(function ChatPane(
+  { conversation, onSend, onEditMessage, onResendMessage, isThinking, onPauseThinking },
+  ref,
+) {
+  const [editingId, setEditingId] = useState(null)
+  const [draft, setDraft] = useState("")
+  const [busy, setBusy] = useState(false)
+  const composerRef = useRef(null)
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      insertTemplate: (templateContent) => {
+        composerRef.current?.insertTemplate(templateContent)
+      },
+    }),
+    [],
+  )
+
+  if (!conversation) return null
+
+  const tags = ["Certified", "Personalized", "Experienced", "Helpful"]
+  const messages = Array.isArray(conversation.messages) ? conversation.messages : []
+  const count = messages.length || conversation.messageCount || 0
+
+  function startEdit(m) {
+    setEditingId(m.id)
+    setDraft(m.content)
+  }
+  function cancelEdit() {
+    setEditingId(null)
+    setDraft("")
+  }
+  function saveEdit() {
+    if (!editingId) return
+    onEditMessage?.(editingId, draft)
+    cancelEdit()
+  }
+  function saveAndResend() {
+    if (!editingId) return
+    onEditMessage?.(editingId, draft)
+    onResendMessage?.(editingId)
+    cancelEdit()
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-1 flex-col">
+      <div className="flex-1 space-y-5 overflow-y-auto px-4 py-6 sm:px-8">
+        <div className="mb-2 text-3xl font-serif tracking-tight sm:text-4xl md:text-5xl">
+          <span className="block leading-[1.05] font-sans text-2xl">{conversation.title}</span>
+        </div>
+        <div className="mb-4 text-sm text-zinc-500 dark:text-zinc-400">
+          Updated {timeAgo(conversation.updatedAt)} · {count} messages
+        </div>
+
+        <div className="mb-6 flex flex-wrap gap-2 border-b border-zinc-200 pb-5 dark:border-zinc-800">
+          {tags.map((t) => (
+            <span
+              key={t}
+              className="inline-flex items-center rounded-full border border-zinc-200 px-3 py-1 text-xs text-zinc-700 dark:border-zinc-800 dark:text-zinc-200"
+            >
+              {t}
+            </span>
+          ))}
+        </div>
+
+        {messages.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-zinc-300 p-6 text-sm text-zinc-500 dark:border-zinc-700 dark:text-zinc-400">
+            No messages yet. Say hello to start.
+          </div>
+        ) : (
+          <>
+            {messages.map((m) => (
+              <div key={m.id} className="space-y-2">
+                {editingId === m.id ? (
+                  <div className={cls("rounded-2xl border p-2", "border-zinc-200 dark:border-zinc-800")}>
+                    <textarea
+                      value={draft}
+                      onChange={(e) => setDraft(e.target.value)}
+                      className="w-full resize-y rounded-xl bg-transparent p-2 text-sm outline-none"
+                      rows={3}
+                    />
+                    <div className="mt-2 flex items-center gap-2">
+                      <button
+                        onClick={saveEdit}
+                        className="inline-flex items-center gap-1 rounded-full bg-zinc-900 px-3 py-1.5 text-xs text-white dark:bg-white dark:text-zinc-900"
+                      >
+                        <Check className="h-3.5 w-3.5" /> Save
+                      </button>
+                      <button
+                        onClick={saveAndResend}
+                        className="inline-flex items-center gap-1 rounded-full border px-3 py-1.5 text-xs"
+                      >
+                        <RefreshCw className="h-3.5 w-3.5" /> Save & Resend
+                      </button>
+                      <button
+                        onClick={cancelEdit}
+                        className="inline-flex items-center gap-1 rounded-full px-3 py-1.5 text-xs"
+                      >
+                        <X className="h-3.5 w-3.5" /> Cancel
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <Message role={m.role}>
+                    <div className="whitespace-pre-wrap">{m.content}</div>
+                    {m.role === "user" && (
+                      <div className="mt-1 flex gap-2 text-[11px] text-zinc-500">
+                        <button className="inline-flex items-center gap-1 hover:underline" onClick={() => startEdit(m)}>
+                          <Pencil className="h-3.5 w-3.5" /> Edit
+                        </button>
+                        <button
+                          className="inline-flex items-center gap-1 hover:underline"
+                          onClick={() => onResendMessage?.(m.id)}
+                        >
+                          <RefreshCw className="h-3.5 w-3.5" /> Resend
+                        </button>
+                      </div>
+                    )}
+                  </Message>
+                )}
+              </div>
+            ))}
+            {isThinking && <ThinkingMessage onPause={onPauseThinking} />}
+          </>
+        )}
+      </div>
+
+      <Composer
+        ref={composerRef}
+        onSend={async (text) => {
+          if (!text.trim()) return
+          setBusy(true)
+          await onSend?.(text)
+          setBusy(false)
+        }}
+        busy={busy}
+      />
+    </div>
+  )
+})
+
+export default ChatPane

--- a/frontend/src/components/ChatPane.jsx
+++ b/frontend/src/components/ChatPane.jsx
@@ -48,7 +48,7 @@ const ChatPane = forwardRef(function ChatPane(
 
   if (!conversation) return null
 
-  const tags = ["Certified", "Personalized", "Experienced", "Helpful"]
+  const tags = []
   const messages = Array.isArray(conversation.messages) ? conversation.messages : []
   const count = messages.length || conversation.messageCount || 0
 
@@ -75,11 +75,11 @@ const ChatPane = forwardRef(function ChatPane(
   return (
     <div className="flex h-full min-h-0 flex-1 flex-col">
       <div className="flex-1 space-y-5 overflow-y-auto px-4 py-6 sm:px-8">
-        <div className="mb-2 text-3xl font-serif tracking-tight sm:text-4xl md:text-5xl">
-          <span className="block leading-[1.05] font-sans text-2xl">{conversation.title}</span>
+        <div className="mb-2 text-3xl tracking-tight sm:text-4xl md:text-5xl">
+          <span className="block leading-[1.05] font-title text-2xl">{conversation.title}</span>
         </div>
         <div className="mb-4 text-sm text-zinc-500 dark:text-zinc-400">
-          Updated {timeAgo(conversation.updatedAt)} · {count} messages
+          Updated {timeAgo(conversation.updatedAt)}
         </div>
 
         <div className="mb-6 flex flex-wrap gap-2 border-b border-zinc-200 pb-5 dark:border-zinc-800">

--- a/frontend/src/components/Composer.jsx
+++ b/frontend/src/components/Composer.jsx
@@ -1,0 +1,159 @@
+"use client"
+
+import { useRef, useState, forwardRef, useImperativeHandle, useEffect } from "react"
+import { Send, Loader2, Plus, Mic } from "lucide-react"
+import ComposerActionsPopover from "./ComposerActionsPopover"
+import { cls } from "./utils"
+
+const Composer = forwardRef(function Composer({ onSend, busy }, ref) {
+  const [value, setValue] = useState("")
+  const [sending, setSending] = useState(false)
+  const [isFocused, setIsFocused] = useState(false)
+  const [lineCount, setLineCount] = useState(1)
+  const inputRef = useRef(null)
+
+  useEffect(() => {
+    if (inputRef.current) {
+      const textarea = inputRef.current
+      const lineHeight = 20 // Approximate line height in pixels
+      const minHeight = 40
+
+      // Reset height to calculate scroll height
+      textarea.style.height = "auto"
+      const scrollHeight = textarea.scrollHeight
+      const calculatedLines = Math.max(1, Math.floor((scrollHeight - 16) / lineHeight)) // 16px for padding
+
+      setLineCount(calculatedLines)
+
+      if (calculatedLines <= 12) {
+        // Auto-expand for 1-12 lines
+        textarea.style.height = `${Math.max(minHeight, scrollHeight)}px`
+        textarea.style.overflowY = "hidden"
+      } else {
+        // Fixed height with scroll for 12+ lines
+        textarea.style.height = `${minHeight + 11 * lineHeight}px` // 12 lines total
+        textarea.style.overflowY = "auto"
+      }
+    }
+  }, [value])
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      insertTemplate: (templateContent) => {
+        setValue((prev) => {
+          const newValue = prev ? `${prev}\n\n${templateContent}` : templateContent
+          setTimeout(() => {
+            inputRef.current?.focus()
+            const length = newValue.length
+            inputRef.current?.setSelectionRange(length, length)
+          }, 0)
+          return newValue
+        })
+      },
+      focus: () => {
+        inputRef.current?.focus()
+      },
+    }),
+    [],
+  )
+
+  async function handleSend() {
+    if (!value.trim() || sending) return
+    setSending(true)
+    try {
+      await onSend?.(value)
+      setValue("")
+      inputRef.current?.focus()
+    } finally {
+      setSending(false)
+    }
+  }
+
+  const hasContent = value.length > 0
+
+  return (
+    <div className="border-t border-zinc-200/60 p-4 dark:border-zinc-800">
+      <div
+        className={cls(
+          "mx-auto flex flex-col rounded-2xl border bg-white shadow-sm dark:bg-zinc-950 transition-all duration-200",
+          "max-w-3xl border-zinc-300 dark:border-zinc-700 p-3",
+        )}
+      >
+        <div className="flex-1 relative">
+          <textarea
+            ref={inputRef}
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
+            placeholder="How can I help you today?"
+            rows={1}
+            className={cls(
+              "w-full resize-none bg-transparent text-sm outline-none placeholder:text-zinc-400 transition-all duration-200",
+              "px-0 py-2 min-h-[40px] text-left",
+            )}
+            style={{
+              height: "auto",
+              overflowY: lineCount > 12 ? "auto" : "hidden",
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault()
+                handleSend()
+              }
+            }}
+          />
+        </div>
+
+        <div className="flex items-center justify-between mt-2">
+          <ComposerActionsPopover>
+            <button
+              className="inline-flex shrink-0 items-center justify-center rounded-full p-2 text-zinc-500 hover:bg-zinc-100 hover:text-zinc-700 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-300 transition-colors"
+              title="Add attachment"
+            >
+              <Plus className="h-4 w-4" />
+            </button>
+          </ComposerActionsPopover>
+
+          <div className="flex items-center gap-1 shrink-0">
+            <button
+              className="inline-flex items-center justify-center rounded-full p-2 text-zinc-500 hover:bg-zinc-100 hover:text-zinc-700 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-300 transition-colors"
+              title="Voice input"
+            >
+              <Mic className="h-4 w-4" />
+            </button>
+            <button
+              onClick={handleSend}
+              disabled={sending || busy || !value.trim()}
+              className={cls(
+                "inline-flex shrink-0 items-center gap-2 rounded-full bg-zinc-900 px-3 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-zinc-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:bg-white dark:text-zinc-900",
+                (sending || busy || !value.trim()) && "opacity-50 cursor-not-allowed",
+              )}
+            >
+              {sending || busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="mx-auto mt-2 max-w-3xl px-1 text-[11px] text-zinc-500 dark:text-zinc-400">
+        Press{" "}
+        <kbd className="rounded border border-zinc-300 bg-zinc-50 px-1 dark:border-zinc-600 dark:bg-zinc-800">
+          Enter
+        </kbd>{" "}
+        to send ·{" "}
+        <kbd className="rounded border border-zinc-300 bg-zinc-50 px-1 dark:border-zinc-600 dark:bg-zinc-800">
+          Shift
+        </kbd>
+        +
+        <kbd className="rounded border border-zinc-300 bg-zinc-50 px-1 dark:border-zinc-600 dark:bg-zinc-800">
+          Enter
+        </kbd>{" "}
+        for newline
+      </div>
+    </div>
+  )
+})
+
+export default Composer

--- a/frontend/src/components/Composer.jsx
+++ b/frontend/src/components/Composer.jsx
@@ -12,6 +12,7 @@ const Composer = forwardRef(function Composer({ onSend, busy }, ref) {
   const [lineCount, setLineCount] = useState(1)
   const inputRef = useRef(null)
 
+  // Auto-resize textarea based on content with max height limit
   useEffect(() => {
     if (inputRef.current) {
       const textarea = inputRef.current
@@ -37,12 +38,15 @@ const Composer = forwardRef(function Composer({ onSend, busy }, ref) {
     }
   }, [value])
 
+  // Expose methods to parent component via ref
   useImperativeHandle(
     ref,
     () => ({
+      // Insert template content into composer, maintaining existing text
       insertTemplate: (templateContent) => {
         setValue((prev) => {
           const newValue = prev ? `${prev}\n\n${templateContent}` : templateContent
+          // Focus and position cursor at end after state update
           setTimeout(() => {
             inputRef.current?.focus()
             const length = newValue.length
@@ -51,6 +55,7 @@ const Composer = forwardRef(function Composer({ onSend, busy }, ref) {
           return newValue
         })
       },
+      // Focus the input field
       focus: () => {
         inputRef.current?.focus()
       },
@@ -58,13 +63,14 @@ const Composer = forwardRef(function Composer({ onSend, busy }, ref) {
     [],
   )
 
+  // Handle sending message with validation and cleanup
   async function handleSend() {
     if (!value.trim() || sending) return
     setSending(true)
     try {
       await onSend?.(value)
-      setValue("")
-      inputRef.current?.focus()
+      setValue("") // Clear input after sending
+      inputRef.current?.focus() // Keep focus for continuous typing
     } finally {
       setSending(false)
     }
@@ -87,7 +93,7 @@ const Composer = forwardRef(function Composer({ onSend, busy }, ref) {
             onChange={(e) => setValue(e.target.value)}
             onFocus={() => setIsFocused(true)}
             onBlur={() => setIsFocused(false)}
-            placeholder="How can I help you today?"
+            placeholder="Ask Reef..."
             rows={1}
             className={cls(
               "w-full resize-none bg-transparent text-sm outline-none placeholder:text-zinc-400 transition-all duration-200",
@@ -117,12 +123,6 @@ const Composer = forwardRef(function Composer({ onSend, busy }, ref) {
           </ComposerActionsPopover>
 
           <div className="flex items-center gap-1 shrink-0">
-            <button
-              className="inline-flex items-center justify-center rounded-full p-2 text-zinc-500 hover:bg-zinc-100 hover:text-zinc-700 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-300 transition-colors"
-              title="Voice input"
-            >
-              <Mic className="h-4 w-4" />
-            </button>
             <button
               onClick={handleSend}
               disabled={sending || busy || !value.trim()}

--- a/frontend/src/components/ComposerActionsPopover.jsx
+++ b/frontend/src/components/ComposerActionsPopover.jsx
@@ -1,0 +1,187 @@
+"use client"
+import { useState } from "react"
+import { Paperclip, Bot, Search, Palette, BookOpen, MoreHorizontal, Globe, ChevronRight } from "lucide-react"
+import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover"
+
+export default function ComposerActionsPopover({ children }) {
+  const [open, setOpen] = useState(false)
+  const [showMore, setShowMore] = useState(false)
+
+  const mainActions = [
+    {
+      icon: Paperclip,
+      label: "Add photos & files",
+      action: () => console.log("Add photos & files"),
+    },
+    {
+      icon: Bot,
+      label: "Agent mode",
+      badge: "NEW",
+      action: () => console.log("Agent mode"),
+    },
+    {
+      icon: Search,
+      label: "Deep research",
+      action: () => console.log("Deep research"),
+    },
+    {
+      icon: Palette,
+      label: "Create image",
+      action: () => console.log("Create image"),
+    },
+    {
+      icon: BookOpen,
+      label: "Study and learn",
+      action: () => console.log("Study and learn"),
+    },
+  ]
+
+  const moreActions = [
+    {
+      icon: Globe,
+      label: "Web search",
+      action: () => console.log("Web search"),
+    },
+    {
+      icon: Palette,
+      label: "Canvas",
+      action: () => console.log("Canvas"),
+    },
+    {
+      icon: () => (
+        <div className="h-4 w-4 rounded bg-gradient-to-br from-blue-500 to-green-500 flex items-center justify-center">
+          <div className="h-2 w-2 bg-white rounded-full" />
+        </div>
+      ),
+      label: "Connect Google Drive",
+      action: () => console.log("Connect Google Drive"),
+    },
+    {
+      icon: () => (
+        <div className="h-4 w-4 rounded bg-gradient-to-br from-blue-600 to-blue-400 flex items-center justify-center">
+          <div className="h-2 w-2 bg-white rounded-full" />
+        </div>
+      ),
+      label: "Connect OneDrive",
+      action: () => console.log("Connect OneDrive"),
+    },
+    {
+      icon: () => (
+        <div className="h-4 w-4 rounded bg-gradient-to-br from-teal-500 to-teal-400 flex items-center justify-center">
+          <div className="h-2 w-2 bg-white rounded-full" />
+        </div>
+      ),
+      label: "Connect Sharepoint",
+      action: () => console.log("Connect Sharepoint"),
+    },
+  ]
+
+  const handleAction = (action) => {
+    action()
+    setOpen(false)
+    setShowMore(false)
+  }
+
+  const handleMoreClick = () => {
+    setShowMore(true)
+  }
+
+  const handleOpenChange = (newOpen) => {
+    setOpen(newOpen)
+    if (!newOpen) {
+      setShowMore(false)
+    }
+  }
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent className="w-96 p-0" align="start" side="top">
+        {!showMore ? (
+          // Main actions view
+          <div className="p-3">
+            <div className="space-y-1">
+              {mainActions.map((action, index) => {
+                const IconComponent = action.icon
+                return (
+                  <button
+                    key={index}
+                    onClick={() => handleAction(action.action)}
+                    className="flex items-center gap-3 w-full p-2 text-sm text-left hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-lg"
+                  >
+                    <IconComponent className="h-4 w-4" />
+                    <span>{action.label}</span>
+                    {action.badge && (
+                      <span className="ml-auto px-2 py-0.5 text-xs bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300 rounded-full">
+                        {action.badge}
+                      </span>
+                    )}
+                  </button>
+                )
+              })}
+              <button
+                onClick={handleMoreClick}
+                className="flex items-center gap-3 w-full p-2 text-sm text-left hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-lg border border-zinc-200 dark:border-zinc-700"
+              >
+                <MoreHorizontal className="h-4 w-4" />
+                <span>More</span>
+                <ChevronRight className="h-4 w-4 ml-auto" />
+              </button>
+            </div>
+          </div>
+        ) : (
+          // More options view with two columns
+          <div className="flex">
+            <div className="flex-1 p-3 border-r border-zinc-200 dark:border-zinc-800">
+              <div className="space-y-1">
+                {mainActions.map((action, index) => {
+                  const IconComponent = action.icon
+                  return (
+                    <button
+                      key={index}
+                      onClick={() => handleAction(action.action)}
+                      className="flex items-center gap-3 w-full p-2 text-sm text-left hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-lg"
+                    >
+                      <IconComponent className="h-4 w-4" />
+                      <span>{action.label}</span>
+                      {action.badge && (
+                        <span className="ml-auto px-2 py-0.5 text-xs bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300 rounded-full">
+                          {action.badge}
+                        </span>
+                      )}
+                    </button>
+                  )
+                })}
+                <button
+                  onClick={handleMoreClick}
+                  className="flex items-center gap-3 w-full p-2 text-sm text-left hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-lg border border-zinc-200 dark:border-zinc-700"
+                >
+                  <MoreHorizontal className="h-4 w-4" />
+                  <span>More</span>
+                  <ChevronRight className="h-4 w-4 ml-auto" />
+                </button>
+              </div>
+            </div>
+            <div className="flex-1 p-3">
+              <div className="space-y-1">
+                {moreActions.map((action, index) => {
+                  const IconComponent = action.icon
+                  return (
+                    <button
+                      key={index}
+                      onClick={() => handleAction(action.action)}
+                      className="flex items-center gap-3 w-full p-2 text-sm text-left hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-lg"
+                    >
+                      {typeof IconComponent === "function" ? <IconComponent /> : <IconComponent className="h-4 w-4" />}
+                      <span>{action.label}</span>
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/frontend/src/components/ConversationRow.jsx
+++ b/frontend/src/components/ConversationRow.jsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { Star } from "lucide-react";
+import { cls, timeAgo } from "./utils";
+
+export default function ConversationRow({ data, active, onSelect, onTogglePin, showMeta }) {
+  const count = Array.isArray(data.messages) ? data.messages.length : data.messageCount;
+  return (
+    <div className="group relative">
+      <button
+        onClick={onSelect}
+        className={cls(
+          "-mx-1 flex w-[calc(100%+8px)] items-center gap-2 rounded-lg px-2 py-2 text-left",
+          active
+            ? "bg-zinc-100 text-zinc-900 dark:bg-zinc-800/60 dark:text-zinc-100"
+            : "hover:bg-zinc-100 dark:hover:bg-zinc-800"
+        )}
+        title={data.title}
+      >
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="truncate text-sm font-medium tracking-tight">{data.title}</span>
+            <span className="shrink-0 text-[11px] text-zinc-500 dark:text-zinc-400">
+              {timeAgo(data.updatedAt)}
+            </span>
+          </div>
+          {showMeta && (
+            <div className="mt-0.5 text-[11px] text-zinc-500 dark:text-zinc-400">
+              {count} messages
+            </div>
+          )}
+        </div>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onTogglePin();
+          }}
+          title={data.pinned ? "Unpin" : "Pin"}
+          className="rounded-md p-1 text-zinc-500 opacity-0 transition group-hover:opacity-100 hover:bg-zinc-200/50 dark:text-zinc-300 dark:hover:bg-zinc-700/60"
+          aria-label={data.pinned ? "Unpin conversation" : "Pin conversation"}
+        >
+          {data.pinned ? (
+            <Star className="h-4 w-4 fill-zinc-800 text-zinc-800 dark:fill-zinc-200 dark:text-zinc-200" />
+          ) : (
+            <Star className="h-4 w-4" />
+          )}
+        </button>
+      </button>
+
+      <div className="pointer-events-none absolute left-[calc(100%+6px)] top-1 hidden w-64 rounded-xl border border-zinc-200 bg-white p-3 text-xs text-zinc-700 shadow-lg dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-200 md:group-hover:block">
+        <div className="line-clamp-6 whitespace-pre-wrap">{data.preview}</div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/CreateFolderModal.jsx
+++ b/frontend/src/components/CreateFolderModal.jsx
@@ -1,0 +1,90 @@
+"use client"
+import { motion, AnimatePresence } from "framer-motion"
+import { X, Lightbulb } from "lucide-react"
+import { useState } from "react"
+
+export default function CreateFolderModal({ isOpen, onClose, onCreateFolder }) {
+  const [folderName, setFolderName] = useState("")
+
+  const handleSubmit = (e) => {
+    e.preventDefault()
+    if (folderName.trim()) {
+      onCreateFolder(folderName.trim())
+      setFolderName("")
+      onClose()
+    }
+  }
+
+  const handleCancel = () => {
+    setFolderName("")
+    onClose()
+  }
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <>
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 z-50 bg-black/60"
+            onClick={handleCancel}
+          />
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.95 }}
+            className="fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-zinc-200 bg-white p-6 shadow-xl dark:border-zinc-800 dark:bg-zinc-900"
+          >
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-semibold">Folder name</h2>
+              <button onClick={handleCancel} className="rounded-lg p-1 hover:bg-zinc-100 dark:hover:bg-zinc-800">
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+
+            <form onSubmit={handleSubmit}>
+              <input
+                type="text"
+                value={folderName}
+                onChange={(e) => setFolderName(e.target.value)}
+                placeholder="E.g. Marketing Projects"
+                className="w-full rounded-lg border border-zinc-300 px-4 py-3 text-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 dark:border-zinc-700 dark:bg-zinc-800"
+                autoFocus
+              />
+
+              <div className="mt-4 flex items-start gap-3 rounded-lg bg-zinc-50 p-4 dark:bg-zinc-800/50">
+                <Lightbulb className="h-5 w-5 text-zinc-500 mt-0.5 shrink-0" />
+                <div className="text-sm text-zinc-600 dark:text-zinc-400">
+                  <div className="font-medium mb-1">What's a folder?</div>
+                  <div>
+                    Folders keep chats, files, and custom instructions in one place. Use them for ongoing work, or just
+                    to keep things tidy.
+                  </div>
+                </div>
+              </div>
+
+              <div className="flex gap-3 mt-6">
+                <button
+                  type="button"
+                  onClick={handleCancel}
+                  className="flex-1 rounded-lg border border-zinc-300 px-4 py-2 text-sm font-medium hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={!folderName.trim()}
+                  className="flex-1 rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-100"
+                >
+                  Create folder
+                </button>
+              </div>
+            </form>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/frontend/src/components/CreateTemplateModal.jsx
+++ b/frontend/src/components/CreateTemplateModal.jsx
@@ -1,0 +1,134 @@
+"use client"
+import { motion, AnimatePresence } from "framer-motion"
+import { X, Lightbulb } from "lucide-react"
+import { useState } from "react"
+
+export default function CreateTemplateModal({ isOpen, onClose, onCreateTemplate, editingTemplate = null }) {
+  const [templateName, setTemplateName] = useState(editingTemplate?.name || "")
+  const [templateContent, setTemplateContent] = useState(editingTemplate?.content || "")
+
+  const isEditing = !!editingTemplate
+
+  const handleSubmit = (e) => {
+    e.preventDefault()
+    if (templateName.trim() && templateContent.trim()) {
+      const templateData = {
+        name: templateName.trim(),
+        content: templateContent.trim(),
+        snippet: templateContent.trim().slice(0, 100) + (templateContent.trim().length > 100 ? "..." : ""),
+        createdAt: editingTemplate?.createdAt || new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      }
+
+      if (isEditing) {
+        onCreateTemplate({ ...templateData, id: editingTemplate.id })
+      } else {
+        onCreateTemplate(templateData)
+      }
+
+      handleCancel()
+    }
+  }
+
+  const handleCancel = () => {
+    setTemplateName("")
+    setTemplateContent("")
+    onClose()
+  }
+
+  // Update form when editingTemplate changes
+  useState(() => {
+    if (editingTemplate) {
+      setTemplateName(editingTemplate.name || "")
+      setTemplateContent(editingTemplate.content || "")
+    }
+  }, [editingTemplate])
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <>
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 z-50 bg-black/60"
+            onClick={handleCancel}
+          />
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.95 }}
+            className="fixed left-1/2 top-1/2 z-50 w-full max-w-2xl -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-zinc-200 bg-white p-6 shadow-xl dark:border-zinc-800 dark:bg-zinc-900"
+          >
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-semibold">{isEditing ? "Edit Template" : "Create Template"}</h2>
+              <button onClick={handleCancel} className="rounded-lg p-1 hover:bg-zinc-100 dark:hover:bg-zinc-800">
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <label htmlFor="templateName" className="block text-sm font-medium mb-2">
+                  Template Name
+                </label>
+                <input
+                  id="templateName"
+                  type="text"
+                  value={templateName}
+                  onChange={(e) => setTemplateName(e.target.value)}
+                  placeholder="E.g. Email Response, Code Review, Meeting Notes"
+                  className="w-full rounded-lg border border-zinc-300 px-4 py-3 text-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 dark:border-zinc-700 dark:bg-zinc-800"
+                  autoFocus
+                />
+              </div>
+
+              <div>
+                <label htmlFor="templateContent" className="block text-sm font-medium mb-2">
+                  Template Content
+                </label>
+                <textarea
+                  id="templateContent"
+                  value={templateContent}
+                  onChange={(e) => setTemplateContent(e.target.value)}
+                  placeholder="Enter your template content here. This will be inserted into the chat when you use the template."
+                  rows={8}
+                  className="w-full rounded-lg border border-zinc-300 px-4 py-3 text-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 dark:border-zinc-700 dark:bg-zinc-800 resize-none"
+                />
+              </div>
+
+              <div className="flex items-start gap-3 rounded-lg bg-zinc-50 p-4 dark:bg-zinc-800/50">
+                <Lightbulb className="h-5 w-5 text-zinc-500 mt-0.5 shrink-0" />
+                <div className="text-sm text-zinc-600 dark:text-zinc-400">
+                  <div className="font-medium mb-1">Pro tip</div>
+                  <div>
+                    Templates are perfect for frequently used prompts, instructions, or conversation starters. They'll
+                    be inserted directly into your chat input when selected.
+                  </div>
+                </div>
+              </div>
+
+              <div className="flex gap-3 pt-2">
+                <button
+                  type="button"
+                  onClick={handleCancel}
+                  className="flex-1 rounded-lg border border-zinc-300 px-4 py-2 text-sm font-medium hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={!templateName.trim() || !templateContent.trim()}
+                  className="flex-1 rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-100"
+                >
+                  {isEditing ? "Update Template" : "Create Template"}
+                </button>
+              </div>
+            </form>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/frontend/src/components/FolderRow.jsx
+++ b/frontend/src/components/FolderRow.jsx
@@ -1,0 +1,147 @@
+"use client"
+
+import { useState, useRef, useEffect } from "react"
+import { FolderIcon, ChevronRight, ChevronDown, MoreHorizontal } from "lucide-react"
+import ConversationRow from "./ConversationRow"
+import { motion, AnimatePresence } from "framer-motion"
+
+export default function FolderRow({
+  name,
+  count,
+  conversations = [],
+  selectedId,
+  onSelect,
+  togglePin,
+  onDeleteFolder,
+  onRenameFolder,
+}) {
+  const [isExpanded, setIsExpanded] = useState(false)
+  const [showMenu, setShowMenu] = useState(false)
+  const menuRef = useRef(null)
+
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (menuRef.current && !menuRef.current.contains(event.target)) {
+        setShowMenu(false)
+      }
+    }
+
+    if (showMenu) {
+      document.addEventListener("mousedown", handleClickOutside)
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside)
+    }
+  }, [showMenu])
+
+  const handleToggle = () => {
+    setIsExpanded(!isExpanded)
+  }
+
+  const handleRename = () => {
+    const newName = prompt(`Rename folder "${name}" to:`, name)
+    if (newName && newName.trim() && newName !== name) {
+      onRenameFolder?.(name, newName.trim())
+    }
+    setShowMenu(false)
+  }
+
+  const handleDelete = () => {
+    if (
+      confirm(
+        `Are you sure you want to delete the folder "${name}"? This will move all conversations to the root level.`,
+      )
+    ) {
+      onDeleteFolder?.(name)
+    }
+    setShowMenu(false)
+  }
+
+  return (
+    <div className="group">
+      <div className="flex items-center justify-between rounded-lg px-2 py-2 text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800">
+        <button onClick={handleToggle} className="flex items-center gap-2 flex-1 text-left">
+          {isExpanded ? (
+            <ChevronDown className="h-4 w-4 text-zinc-500" />
+          ) : (
+            <ChevronRight className="h-4 w-4 text-zinc-500" />
+          )}
+          <FolderIcon className="h-4 w-4" />
+          <span className="truncate">{name}</span>
+        </button>
+
+        <div className="flex items-center gap-1">
+          <span className="rounded-md bg-zinc-100 px-1.5 py-0.5 text-[11px] text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
+            {count}
+          </span>
+
+          <div className="relative" ref={menuRef}>
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                setShowMenu(!showMenu)
+              }}
+              className="opacity-0 group-hover:opacity-100 p-1 rounded hover:bg-zinc-200 dark:hover:bg-zinc-700 transition-opacity"
+            >
+              <MoreHorizontal className="h-3 w-3" />
+            </button>
+
+            <AnimatePresence>
+              {showMenu && (
+                <motion.div
+                  initial={{ opacity: 0, scale: 0.95 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.95 }}
+                  className="absolute right-0 top-full mt-1 w-32 rounded-lg border border-zinc-200 bg-white py-1 shadow-lg dark:border-zinc-800 dark:bg-zinc-900 z-[100]"
+                >
+                  <button
+                    onClick={handleRename}
+                    className="w-full px-3 py-1.5 text-left text-xs hover:bg-zinc-100 dark:hover:bg-zinc-800"
+                  >
+                    Rename
+                  </button>
+                  <button
+                    onClick={handleDelete}
+                    className="w-full px-3 py-1.5 text-left text-xs text-red-600 hover:bg-zinc-100 dark:hover:bg-zinc-800"
+                  >
+                    Delete
+                  </button>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
+        </div>
+      </div>
+
+      <AnimatePresence>
+        {isExpanded && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            className="overflow-hidden"
+          >
+            <div className="ml-6 space-y-1 py-1">
+              {conversations.map((conversation) => (
+                <ConversationRow
+                  key={conversation.id}
+                  data={conversation}
+                  active={conversation.id === selectedId}
+                  onSelect={() => onSelect(conversation.id)}
+                  onTogglePin={() => togglePin(conversation.id)}
+                  showMeta
+                />
+              ))}
+              {conversations.length === 0 && (
+                <div className="px-2 py-2 text-xs text-zinc-500 dark:text-zinc-400">
+                  No conversations in this folder
+                </div>
+              )}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  )
+}

--- a/frontend/src/components/GhostIconButton.jsx
+++ b/frontend/src/components/GhostIconButton.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+export default function GhostIconButton({ label, children }) {
+  return (
+    <button
+      className="hidden rounded-full border border-zinc-200 bg-white/70 p-2 text-zinc-700 hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 md:inline-flex dark:border-zinc-800 dark:bg-zinc-900/70 dark:text-zinc-200"
+      aria-label={label}
+      title={label}
+    >
+      {children}
+    </button>
+  );
+}

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,0 +1,69 @@
+"use client"
+import { Asterisk, MoreHorizontal, Menu, ChevronDown } from "lucide-react"
+import { useState } from "react"
+import GhostIconButton from "./GhostIconButton"
+
+export default function Header({ createNewChat, sidebarCollapsed, setSidebarOpen }) {
+  const [selectedBot, setSelectedBot] = useState("GPT-5")
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false)
+
+  const chatbots = [
+    { name: "GPT-5", icon: "🤖" },
+    { name: "Claude Sonnet 4", icon: "🎭" },
+    { name: "Gemini", icon: "💎" },
+    { name: "Assistant", icon: <Asterisk className="h-4 w-4" /> },
+  ]
+
+  return (
+    <div className="sticky top-0 z-30 flex items-center gap-2 border-b border-zinc-200/60 bg-white/80 px-4 py-3 backdrop-blur dark:border-zinc-800 dark:bg-zinc-900/70">
+      {sidebarCollapsed && (
+        <button
+          onClick={() => setSidebarOpen(true)}
+          className="md:hidden inline-flex items-center justify-center rounded-lg p-2 hover:bg-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:hover:bg-zinc-800"
+          aria-label="Open sidebar"
+        >
+          <Menu className="h-5 w-5" />
+        </button>
+      )}
+
+      <div className="hidden md:flex relative">
+        <button
+          onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+          className="inline-flex items-center gap-2 rounded-full border border-zinc-200 bg-white px-3 py-2 text-sm font-semibold tracking-tight hover:bg-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:border-zinc-800 dark:bg-zinc-950 dark:hover:bg-zinc-800"
+        >
+          {typeof chatbots.find((bot) => bot.name === selectedBot)?.icon === "string" ? (
+            <span className="text-sm">{chatbots.find((bot) => bot.name === selectedBot)?.icon}</span>
+          ) : (
+            chatbots.find((bot) => bot.name === selectedBot)?.icon
+          )}
+          {selectedBot}
+          <ChevronDown className="h-4 w-4" />
+        </button>
+
+        {isDropdownOpen && (
+          <div className="absolute top-full left-0 mt-1 w-48 rounded-lg border border-zinc-200 bg-white shadow-lg dark:border-zinc-800 dark:bg-zinc-950 z-50">
+            {chatbots.map((bot) => (
+              <button
+                key={bot.name}
+                onClick={() => {
+                  setSelectedBot(bot.name)
+                  setIsDropdownOpen(false)
+                }}
+                className="w-full flex items-center gap-2 px-3 py-2 text-sm text-left hover:bg-zinc-100 dark:hover:bg-zinc-800 first:rounded-t-lg last:rounded-b-lg"
+              >
+                {typeof bot.icon === "string" ? <span className="text-sm">{bot.icon}</span> : bot.icon}
+                {bot.name}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="ml-auto flex items-center gap-2">
+        <GhostIconButton label="More">
+          <MoreHorizontal className="h-4 w-4" />
+        </GhostIconButton>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/Message.jsx
+++ b/frontend/src/components/Message.jsx
@@ -1,0 +1,29 @@
+import { cls } from "./utils"
+
+export default function Message({ role, children }) {
+  const isUser = role === "user"
+  return (
+    <div className={cls("flex gap-3", isUser ? "justify-end" : "justify-start")}>
+      {!isUser && (
+        <div className="mt-0.5 grid h-7 w-7 place-items-center rounded-full bg-zinc-900 text-[10px] font-bold text-white dark:bg-white dark:text-zinc-900">
+          AI
+        </div>
+      )}
+      <div
+        className={cls(
+          "max-w-[80%] rounded-2xl px-3 py-2 text-sm shadow-sm",
+          isUser
+            ? "bg-zinc-900 text-white dark:bg-white dark:text-zinc-900"
+            : "bg-white text-zinc-900 dark:bg-zinc-900 dark:text-zinc-100 border border-zinc-200 dark:border-zinc-800",
+        )}
+      >
+        {children}
+      </div>
+      {isUser && (
+        <div className="mt-0.5 grid h-7 w-7 place-items-center rounded-full bg-zinc-900 text-[10px] font-bold text-white dark:bg-white dark:text-zinc-900">
+          JD
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/Message.jsx
+++ b/frontend/src/components/Message.jsx
@@ -4,11 +4,6 @@ export default function Message({ role, children }) {
   const isUser = role === "user"
   return (
     <div className={cls("flex gap-3", isUser ? "justify-end" : "justify-start")}>
-      {!isUser && (
-        <div className="mt-0.5 grid h-7 w-7 place-items-center rounded-full bg-zinc-900 text-[10px] font-bold text-white dark:bg-white dark:text-zinc-900">
-          AI
-        </div>
-      )}
       <div
         className={cls(
           "max-w-[80%] rounded-2xl px-3 py-2 text-sm shadow-sm",
@@ -19,11 +14,6 @@ export default function Message({ role, children }) {
       >
         {children}
       </div>
-      {isUser && (
-        <div className="mt-0.5 grid h-7 w-7 place-items-center rounded-full bg-zinc-900 text-[10px] font-bold text-white dark:bg-white dark:text-zinc-900">
-          JD
-        </div>
-      )}
     </div>
   )
 }

--- a/frontend/src/components/SearchModal.jsx
+++ b/frontend/src/components/SearchModal.jsx
@@ -1,0 +1,176 @@
+"use client"
+import { motion, AnimatePresence } from "framer-motion"
+import { X, SearchIcon, Plus, Clock } from "lucide-react"
+import { useState, useEffect, useMemo } from "react"
+
+function getTimeGroup(dateString) {
+  const date = new Date(dateString)
+  const now = new Date()
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000)
+  const sevenDaysAgo = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000)
+
+  if (date >= today) return "Today"
+  if (date >= yesterday) return "Yesterday"
+  if (date >= sevenDaysAgo) return "Previous 7 Days"
+  return "Older"
+}
+
+export default function SearchModal({
+  isOpen,
+  onClose,
+  conversations,
+  selectedId,
+  onSelect,
+  togglePin,
+  createNewChat,
+}) {
+  const [query, setQuery] = useState("")
+
+  const filteredConversations = useMemo(() => {
+    if (!query.trim()) return conversations
+    const q = query.toLowerCase()
+    return conversations.filter((c) => c.title.toLowerCase().includes(q) || c.preview.toLowerCase().includes(q))
+  }, [conversations, query])
+
+  const groupedConversations = useMemo(() => {
+    const groups = {
+      Today: [],
+      Yesterday: [],
+      "Previous 7 Days": [],
+      Older: [],
+    }
+
+    filteredConversations
+      .sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt))
+      .forEach((conv) => {
+        const group = getTimeGroup(conv.updatedAt)
+        groups[group].push(conv)
+      })
+
+    return groups
+  }, [filteredConversations])
+
+  const handleClose = () => {
+    setQuery("")
+    onClose()
+  }
+
+  const handleNewChat = () => {
+    createNewChat()
+    handleClose()
+  }
+
+  const handleSelectConversation = (id) => {
+    onSelect(id)
+    handleClose()
+  }
+
+  useEffect(() => {
+    const handleEscape = (e) => {
+      if (e.key === "Escape") handleClose()
+    }
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleEscape)
+      return () => document.removeEventListener("keydown", handleEscape)
+    }
+  }, [isOpen])
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <>
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 z-50 bg-black/60"
+            onClick={handleClose}
+          />
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95, y: -20 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.95, y: -20 }}
+            className="fixed left-1/2 top-[20%] z-50 w-full max-w-2xl -translate-x-1/2 rounded-2xl border border-zinc-200 bg-white shadow-2xl dark:border-zinc-800 dark:bg-zinc-900"
+          >
+            {/* Search Header */}
+            <div className="flex items-center gap-3 border-b border-zinc-200 p-4 dark:border-zinc-800">
+              <SearchIcon className="h-5 w-5 text-zinc-400" />
+              <input
+                type="text"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Search chats..."
+                className="flex-1 bg-transparent text-lg outline-none placeholder:text-zinc-400"
+                autoFocus
+              />
+              <button onClick={handleClose} className="rounded-lg p-1.5 hover:bg-zinc-100 dark:hover:bg-zinc-800">
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+
+            {/* Search Results */}
+            <div className="max-h-[60vh] overflow-y-auto">
+              {/* New Chat Option */}
+              <div className="border-b border-zinc-200 p-2 dark:border-zinc-800">
+                <button
+                  onClick={handleNewChat}
+                  className="flex w-full items-center gap-3 rounded-lg p-3 text-left hover:bg-zinc-100 dark:hover:bg-zinc-800"
+                >
+                  <Plus className="h-5 w-5 text-zinc-500" />
+                  <span className="font-medium">New chat</span>
+                </button>
+              </div>
+
+              {/* Conversation Groups */}
+              {Object.entries(groupedConversations).map(([groupName, convs]) => {
+                if (convs.length === 0) return null
+
+                return (
+                  <div key={groupName} className="border-b border-zinc-200 p-2 last:border-b-0 dark:border-zinc-800">
+                    <div className="px-3 py-2 text-xs font-medium text-zinc-500 dark:text-zinc-400">{groupName}</div>
+                    <div className="space-y-1">
+                      {convs.map((conv) => (
+                        <button
+                          key={conv.id}
+                          onClick={() => handleSelectConversation(conv.id)}
+                          className="flex w-full items-center gap-3 rounded-lg p-3 text-left hover:bg-zinc-100 dark:hover:bg-zinc-800"
+                        >
+                          <Clock className="h-4 w-4 text-zinc-400 shrink-0" />
+                          <div className="min-w-0 flex-1">
+                            <div className="truncate font-medium">{conv.title}</div>
+                            <div className="truncate text-sm text-zinc-500 dark:text-zinc-400">{conv.preview}</div>
+                          </div>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )
+              })}
+
+              {/* Empty State */}
+              {filteredConversations.length === 0 && query.trim() && (
+                <div className="p-8 text-center">
+                  <SearchIcon className="mx-auto h-12 w-12 text-zinc-300 dark:text-zinc-600" />
+                  <div className="mt-4 text-lg font-medium text-zinc-900 dark:text-zinc-100">No chats found</div>
+                  <div className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
+                    Try searching with different keywords
+                  </div>
+                </div>
+              )}
+
+              {/* Default State - Show all conversations when no query */}
+              {!query.trim() && conversations.length === 0 && (
+                <div className="p-8 text-center">
+                  <div className="text-lg font-medium text-zinc-900 dark:text-zinc-100">No conversations yet</div>
+                  <div className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">Start a new chat to begin</div>
+                </div>
+              )}
+            </div>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/frontend/src/components/SettingsPopover.jsx
+++ b/frontend/src/components/SettingsPopover.jsx
@@ -1,0 +1,69 @@
+"use client"
+import { useState } from "react"
+import { User, Globe, HelpCircle, Crown, BookOpen, LogOut, ChevronRight } from "lucide-react"
+import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover"
+
+export default function SettingsPopover({ children }) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent className="w-80 p-0" align="start" side="top">
+        <div className="p-4">
+          <div className="text-sm text-zinc-600 dark:text-zinc-400 mb-3">j@gmail.com</div>
+
+          <div className="flex items-center gap-3 p-3 rounded-lg bg-zinc-50 dark:bg-zinc-800/50 mb-4">
+            <div className="flex items-center gap-2">
+              <User className="h-4 w-4" />
+              <span className="text-sm font-medium">Personal</span>
+            </div>
+            <div className="ml-auto">
+              <div className="text-xs text-zinc-500">Pro plan</div>
+            </div>
+            <div className="text-blue-500">
+              <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
+                <path
+                  fillRule="evenodd"
+                  d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </div>
+          </div>
+
+          <div className="space-y-1">
+            <div className="text-sm font-medium text-zinc-900 dark:text-zinc-100 mb-2">Settings</div>
+
+            <button className="flex items-center gap-3 w-full p-2 text-sm text-left hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-lg">
+              <Globe className="h-4 w-4" />
+              <span>Language</span>
+              <ChevronRight className="h-4 w-4 ml-auto" />
+            </button>
+
+            <button className="flex items-center gap-3 w-full p-2 text-sm text-left hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-lg">
+              <HelpCircle className="h-4 w-4" />
+              <span>Get help</span>
+            </button>
+
+            <button className="flex items-center gap-3 w-full p-2 text-sm text-left hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-lg">
+              <Crown className="h-4 w-4" />
+              <span>Upgrade plan</span>
+            </button>
+
+            <button className="flex items-center gap-3 w-full p-2 text-sm text-left hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-lg">
+              <BookOpen className="h-4 w-4" />
+              <span>Learn more</span>
+              <ChevronRight className="h-4 w-4 ml-auto" />
+            </button>
+
+            <button className="flex items-center gap-3 w-full p-2 text-sm text-left hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-lg">
+              <LogOut className="h-4 w-4" />
+              <span>Log out</span>
+            </button>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,0 +1,425 @@
+"use client"
+import { motion, AnimatePresence } from "framer-motion"
+import {
+  PanelLeftClose,
+  PanelLeftOpen,
+  SearchIcon,
+  Plus,
+  Star,
+  Clock,
+  FolderIcon,
+  FileText,
+  Settings,
+  Asterisk,
+} from "lucide-react"
+import SidebarSection from "./SidebarSection"
+import ConversationRow from "./ConversationRow"
+import FolderRow from "./FolderRow"
+import TemplateRow from "./TemplateRow"
+import ThemeToggle from "./ThemeToggle"
+import CreateFolderModal from "./CreateFolderModal"
+import CreateTemplateModal from "./CreateTemplateModal"
+import SearchModal from "./SearchModal"
+import SettingsPopover from "./SettingsPopover"
+import { cls } from "./utils"
+import { useState } from "react"
+
+export default function Sidebar({
+  open,
+  onClose,
+  theme,
+  setTheme,
+  collapsed,
+  setCollapsed,
+  conversations,
+  pinned,
+  recent,
+  folders,
+  folderCounts,
+  selectedId,
+  onSelect,
+  togglePin,
+  query,
+  setQuery,
+  searchRef,
+  createFolder,
+  createNewChat,
+  templates = [],
+  setTemplates = () => {},
+  onUseTemplate = () => {},
+  sidebarCollapsed = false,
+  setSidebarCollapsed = () => {},
+}) {
+  const [showCreateFolderModal, setShowCreateFolderModal] = useState(false)
+  const [showCreateTemplateModal, setShowCreateTemplateModal] = useState(false)
+  const [editingTemplate, setEditingTemplate] = useState(null)
+  const [showSearchModal, setShowSearchModal] = useState(false)
+
+  const getConversationsByFolder = (folderName) => {
+    return conversations.filter((conv) => conv.folder === folderName)
+  }
+
+  const handleCreateFolder = (folderName) => {
+    createFolder(folderName)
+  }
+
+  const handleDeleteFolder = (folderName) => {
+    const updatedConversations = conversations.map((conv) =>
+      conv.folder === folderName ? { ...conv, folder: null } : conv,
+    )
+    console.log("Delete folder:", folderName, "Updated conversations:", updatedConversations)
+  }
+
+  const handleRenameFolder = (oldName, newName) => {
+    const updatedConversations = conversations.map((conv) =>
+      conv.folder === oldName ? { ...conv, folder: newName } : conv,
+    )
+    console.log("Rename folder:", oldName, "to", newName, "Updated conversations:", updatedConversations)
+  }
+
+  const handleCreateTemplate = (templateData) => {
+    if (editingTemplate) {
+      const updatedTemplates = templates.map((t) =>
+        t.id === editingTemplate.id ? { ...templateData, id: editingTemplate.id } : t,
+      )
+      setTemplates(updatedTemplates)
+      setEditingTemplate(null)
+    } else {
+      const newTemplate = {
+        ...templateData,
+        id: Date.now().toString(),
+      }
+      setTemplates([...templates, newTemplate])
+    }
+    setShowCreateTemplateModal(false)
+  }
+
+  const handleEditTemplate = (template) => {
+    setEditingTemplate(template)
+    setShowCreateTemplateModal(true)
+  }
+
+  const handleRenameTemplate = (templateId, newName) => {
+    const updatedTemplates = templates.map((t) =>
+      t.id === templateId ? { ...t, name: newName, updatedAt: new Date().toISOString() } : t,
+    )
+    setTemplates(updatedTemplates)
+  }
+
+  const handleDeleteTemplate = (templateId) => {
+    const updatedTemplates = templates.filter((t) => t.id !== templateId)
+    setTemplates(updatedTemplates)
+  }
+
+  const handleUseTemplate = (template) => {
+    onUseTemplate(template)
+  }
+
+  if (sidebarCollapsed) {
+    return (
+      <motion.aside
+        initial={{ width: 320 }}
+        animate={{ width: 64 }}
+        transition={{ type: "spring", stiffness: 260, damping: 28 }}
+        className="z-50 flex h-full shrink-0 flex-col border-r border-zinc-200/60 bg-white dark:border-zinc-800 dark:bg-zinc-900"
+      >
+        <div className="flex items-center justify-center border-b border-zinc-200/60 px-3 py-3 dark:border-zinc-800">
+          <button
+            onClick={() => setSidebarCollapsed(false)}
+            className="rounded-xl p-2 hover:bg-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:hover:bg-zinc-800"
+            aria-label="Open sidebar"
+            title="Open sidebar"
+          >
+            <PanelLeftOpen className="h-5 w-5" />
+          </button>
+        </div>
+
+        <div className="flex flex-col items-center gap-4 pt-4">
+          <button
+            onClick={createNewChat}
+            className="rounded-xl p-2 hover:bg-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:hover:bg-zinc-800"
+            title="New Chat"
+          >
+            <Plus className="h-5 w-5" />
+          </button>
+
+          <button
+            onClick={() => setShowSearchModal(true)}
+            className="rounded-xl p-2 hover:bg-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:hover:bg-zinc-800"
+            title="Search"
+          >
+            <SearchIcon className="h-5 w-5" />
+          </button>
+
+          <button
+            className="rounded-xl p-2 hover:bg-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:hover:bg-zinc-800"
+            title="Folders"
+          >
+            <FolderIcon className="h-5 w-5" />
+          </button>
+
+          <div className="mt-auto mb-4">
+            <SettingsPopover>
+              <button
+                className="rounded-xl p-2 hover:bg-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:hover:bg-zinc-800"
+                title="Settings"
+              >
+                <Settings className="h-5 w-5" />
+              </button>
+            </SettingsPopover>
+          </div>
+        </div>
+      </motion.aside>
+    )
+  }
+
+  return (
+    <>
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            key="overlay"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 0.5 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 z-40 bg-black/60 md:hidden"
+            onClick={onClose}
+          />
+        )}
+      </AnimatePresence>
+
+      <AnimatePresence>
+        {(open || typeof window !== "undefined") && (
+          <motion.aside
+            key="sidebar"
+            initial={{ x: -340 }}
+            animate={{ x: open ? 0 : 0 }}
+            exit={{ x: -340 }}
+            transition={{ type: "spring", stiffness: 260, damping: 28 }}
+            className={cls(
+              "z-50 flex h-full w-80 shrink-0 flex-col border-r border-zinc-200/60 bg-white dark:border-zinc-800 dark:bg-zinc-900",
+              "fixed inset-y-0 left-0 md:static md:translate-x-0",
+            )}
+          >
+            <div className="flex items-center gap-2 border-b border-zinc-200/60 px-3 py-3 dark:border-zinc-800">
+              <div className="flex items-center gap-2">
+                <div className="grid h-8 w-8 place-items-center rounded-xl bg-gradient-to-br from-blue-500 to-indigo-500 text-white shadow-sm dark:from-zinc-200 dark:to-zinc-300 dark:text-zinc-900">
+                  <Asterisk className="h-4 w-4" />
+                </div>
+                <div className="text-sm font-semibold tracking-tight">AI Assistant</div>
+              </div>
+              <div className="ml-auto flex items-center gap-1">
+                <button
+                  onClick={() => setSidebarCollapsed(true)}
+                  className="hidden md:block rounded-xl p-2 hover:bg-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:hover:bg-zinc-800"
+                  aria-label="Close sidebar"
+                  title="Close sidebar"
+                >
+                  <PanelLeftClose className="h-5 w-5" />
+                </button>
+
+                <button
+                  onClick={onClose}
+                  className="md:hidden rounded-xl p-2 hover:bg-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:hover:bg-zinc-800"
+                  aria-label="Close sidebar"
+                >
+                  <PanelLeftClose className="h-5 w-5" />
+                </button>
+              </div>
+            </div>
+
+            <div className="px-3 pt-3">
+              <label htmlFor="search" className="sr-only">
+                Search conversations
+              </label>
+              <div className="relative">
+                <SearchIcon className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-zinc-400" />
+                <input
+                  id="search"
+                  ref={searchRef}
+                  type="text"
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder="Search…"
+                  onClick={() => setShowSearchModal(true)}
+                  onFocus={() => setShowSearchModal(true)}
+                  className="w-full rounded-full border border-zinc-200 bg-white py-2 pl-9 pr-3 text-sm outline-none ring-0 placeholder:text-zinc-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500 dark:border-zinc-800 dark:bg-zinc-950/50"
+                />
+              </div>
+            </div>
+
+            <div className="px-3 pt-3">
+              <button
+                onClick={createNewChat}
+                className="flex w-full items-center justify-center gap-2 rounded-full bg-zinc-900 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-zinc-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:bg-white dark:text-zinc-900"
+                title="New Chat (⌘N)"
+              >
+                <Plus className="h-4 w-4" /> Start New Chat
+              </button>
+            </div>
+
+            <nav className="mt-4 flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-2 pb-4">
+              <SidebarSection
+                icon={<Star className="h-4 w-4" />}
+                title="PINNED CHATS" // Renamed from "PINNED CONVERSATIONS" to "PINNED CHATS"
+                collapsed={collapsed.pinned}
+                onToggle={() => setCollapsed((s) => ({ ...s, pinned: !s.pinned }))}
+              >
+                {pinned.length === 0 ? (
+                  <div className="select-none rounded-lg border border-dashed border-zinc-200 px-3 py-3 text-center text-xs text-zinc-500 dark:border-zinc-800 dark:text-zinc-400">
+                    Pin important threads for quick access.
+                  </div>
+                ) : (
+                  pinned.map((c) => (
+                    <ConversationRow
+                      key={c.id}
+                      data={c}
+                      active={c.id === selectedId}
+                      onSelect={() => onSelect(c.id)}
+                      onTogglePin={() => togglePin(c.id)}
+                    />
+                  ))
+                )}
+              </SidebarSection>
+
+              <SidebarSection
+                icon={<Clock className="h-4 w-4" />}
+                title="RECENT"
+                collapsed={collapsed.recent}
+                onToggle={() => setCollapsed((s) => ({ ...s, recent: !s.recent }))}
+              >
+                {recent.length === 0 ? (
+                  <div className="select-none rounded-lg border border-dashed border-zinc-200 px-3 py-3 text-center text-xs text-zinc-500 dark:border-zinc-800 dark:text-zinc-400">
+                    No conversations yet. Start a new one!
+                  </div>
+                ) : (
+                  recent.map((c) => (
+                    <ConversationRow
+                      key={c.id}
+                      data={c}
+                      active={c.id === selectedId}
+                      onSelect={() => onSelect(c.id)}
+                      onTogglePin={() => togglePin(c.id)}
+                      showMeta
+                    />
+                  ))
+                )}
+              </SidebarSection>
+
+              <SidebarSection
+                icon={<FolderIcon className="h-4 w-4" />}
+                title="FOLDERS"
+                collapsed={collapsed.folders}
+                onToggle={() => setCollapsed((s) => ({ ...s, folders: !s.folders }))}
+              >
+                <div className="-mx-1">
+                  <button
+                    onClick={() => setShowCreateFolderModal(true)}
+                    className="mb-2 inline-flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left text-sm text-zinc-600 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                  >
+                    <Plus className="h-4 w-4" /> Create folder
+                  </button>
+
+                  {folders.map((f) => (
+                    <FolderRow
+                      key={f.id}
+                      name={f.name}
+                      count={folderCounts[f.name] || 0}
+                      conversations={getConversationsByFolder(f.name)}
+                      selectedId={selectedId}
+                      onSelect={onSelect}
+                      togglePin={togglePin}
+                      onDeleteFolder={handleDeleteFolder}
+                      onRenameFolder={handleRenameFolder}
+                    />
+                  ))}
+                </div>
+              </SidebarSection>
+
+              <SidebarSection
+                icon={<FileText className="h-4 w-4" />} // Replaced StarOff with FileText for better template metaphor
+                title="TEMPLATES"
+                collapsed={collapsed.templates}
+                onToggle={() => setCollapsed((s) => ({ ...s, templates: !s.templates }))}
+              >
+                <div className="-mx-1">
+                  <button
+                    onClick={() => setShowCreateTemplateModal(true)}
+                    className="mb-2 inline-flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left text-sm text-zinc-600 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                  >
+                    <Plus className="h-4 w-4" /> Create template
+                  </button>
+
+                  {(Array.isArray(templates) ? templates : []).map((template) => (
+                    <TemplateRow
+                      key={template.id}
+                      template={template}
+                      onUseTemplate={handleUseTemplate}
+                      onEditTemplate={handleEditTemplate}
+                      onRenameTemplate={handleRenameTemplate}
+                      onDeleteTemplate={handleDeleteTemplate}
+                    />
+                  ))}
+
+                  {(!templates || templates.length === 0) && (
+                    <div className="select-none rounded-lg border border-dashed border-zinc-200 px-3 py-3 text-center text-xs text-zinc-500 dark:border-zinc-800 dark:text-zinc-400">
+                      No templates yet. Create your first prompt template.
+                    </div>
+                  )}
+                </div>
+              </SidebarSection>
+            </nav>
+
+            <div className="mt-auto border-t border-zinc-200/60 px-3 py-3 dark:border-zinc-800">
+              <div className="flex items-center gap-2">
+                <SettingsPopover>
+                  <button className="inline-flex items-center gap-2 rounded-lg px-2 py-2 text-sm hover:bg-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:hover:bg-zinc-800">
+                    <Settings className="h-4 w-4" /> Settings
+                  </button>
+                </SettingsPopover>
+                <div className="ml-auto">
+                  <ThemeToggle theme={theme} setTheme={setTheme} />
+                </div>
+              </div>
+              <div className="mt-2 flex items-center gap-2 rounded-xl bg-zinc-50 p-2 dark:bg-zinc-800/60">
+                <div className="grid h-8 w-8 place-items-center rounded-full bg-zinc-900 text-xs font-bold text-white dark:bg-white dark:text-zinc-900">
+                  JD
+                </div>
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-medium">John Doe</div>
+                  <div className="truncate text-xs text-zinc-500 dark:text-zinc-400">Pro workspace</div>
+                </div>
+              </div>
+            </div>
+          </motion.aside>
+        )}
+      </AnimatePresence>
+
+      <CreateFolderModal
+        isOpen={showCreateFolderModal}
+        onClose={() => setShowCreateFolderModal(false)}
+        onCreateFolder={handleCreateFolder}
+      />
+
+      <CreateTemplateModal
+        isOpen={showCreateTemplateModal}
+        onClose={() => {
+          setShowCreateTemplateModal(false)
+          setEditingTemplate(null)
+        }}
+        onCreateTemplate={handleCreateTemplate}
+        editingTemplate={editingTemplate}
+      />
+
+      <SearchModal
+        isOpen={showSearchModal}
+        onClose={() => setShowSearchModal(false)}
+        conversations={conversations}
+        selectedId={selectedId}
+        onSelect={onSelect}
+        togglePin={togglePin}
+        createNewChat={createNewChat}
+      />
+    </>
+  )
+}

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -21,7 +21,7 @@ import CreateFolderModal from "./CreateFolderModal"
 import CreateTemplateModal from "./CreateTemplateModal"
 import SearchModal from "./SearchModal"
 import SettingsPopover from "./SettingsPopover"
-import { cls } from "./utils"
+import { cls, makeId } from "./utils"
 import { useState } from "react"
 
 export default function Sidebar({
@@ -85,9 +85,10 @@ export default function Sidebar({
       setTemplates(updatedTemplates)
       setEditingTemplate(null)
     } else {
+      // Create new template with unique ID
       const newTemplate = {
         ...templateData,
-        id: Date.now().toString(),
+        id: makeId("template"),
       }
       setTemplates([...templates, newTemplate])
     }

--- a/frontend/src/components/SidebarSection.jsx
+++ b/frontend/src/components/SidebarSection.jsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { ChevronDown, ChevronRight } from "lucide-react";
+
+export default function SidebarSection({ icon, title, children, collapsed, onToggle }) {
+  return (
+    <section>
+      <button
+        onClick={onToggle}
+        className="sticky top-0 z-10 -mx-2 mb-1 flex w-[calc(100%+16px)] items-center gap-2 border-y border-transparent bg-gradient-to-b from-white to-white/70 px-2 py-2 text-[11px] font-semibold tracking-wide text-zinc-500 backdrop-blur hover:text-zinc-700 dark:from-zinc-900 dark:to-zinc-900/70 dark:hover:text-zinc-300"
+        aria-expanded={!collapsed}
+      >
+        <span className="mr-1" aria-hidden>
+          {collapsed ? <ChevronRight className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
+        </span>
+        <span className="flex items-center gap-2">
+          <span className="opacity-70" aria-hidden>
+            {icon}
+          </span>
+          {title}
+        </span>
+      </button>
+      <AnimatePresence initial={false}>
+        {!collapsed && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.18 }}
+            className="space-y-0.5"
+          >
+            {children}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </section>
+  );
+}

--- a/frontend/src/components/TemplateRow.jsx
+++ b/frontend/src/components/TemplateRow.jsx
@@ -1,0 +1,124 @@
+"use client"
+
+import { useState, useRef, useEffect } from "react"
+import { FileText, MoreHorizontal, Copy, Edit3, Trash2 } from "lucide-react"
+import { motion, AnimatePresence } from "framer-motion"
+
+export default function TemplateRow({ template, onUseTemplate, onEditTemplate, onRenameTemplate, onDeleteTemplate }) {
+  const [showMenu, setShowMenu] = useState(false)
+  const menuRef = useRef(null)
+
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (menuRef.current && !menuRef.current.contains(event.target)) {
+        setShowMenu(false)
+      }
+    }
+
+    if (showMenu) {
+      document.addEventListener("mousedown", handleClickOutside)
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside)
+    }
+  }, [showMenu])
+
+  const handleUse = () => {
+    onUseTemplate?.(template)
+    setShowMenu(false)
+  }
+
+  const handleEdit = () => {
+    onEditTemplate?.(template)
+    setShowMenu(false)
+  }
+
+  const handleRename = () => {
+    const newName = prompt(`Rename template "${template.name}" to:`, template.name)
+    if (newName && newName.trim() && newName !== template.name) {
+      onRenameTemplate?.(template.id, newName.trim())
+    }
+    setShowMenu(false)
+  }
+
+  const handleDelete = () => {
+    if (confirm(`Are you sure you want to delete the template "${template.name}"?`)) {
+      onDeleteTemplate?.(template.id)
+    }
+    setShowMenu(false)
+  }
+
+  return (
+    <div className="group">
+      <div className="flex items-center justify-between rounded-lg px-2 py-2 text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800">
+        <button
+          onClick={handleUse}
+          className="flex items-center gap-2 flex-1 text-left min-w-0"
+          title={`Use template: ${template.snippet}`}
+        >
+          <FileText className="h-4 w-4 text-zinc-500 shrink-0" />
+          <div className="min-w-0 flex-1">
+            <div className="truncate font-medium">{template.name}</div>
+            <div className="truncate text-xs text-zinc-500 dark:text-zinc-400">{template.snippet}</div>
+          </div>
+        </button>
+
+        <div className="flex items-center gap-1">
+          <span className="hidden group-hover:inline text-xs text-zinc-500 dark:text-zinc-400 px-1">Use</span>
+
+          <div className="relative" ref={menuRef}>
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                setShowMenu(!showMenu)
+              }}
+              className="opacity-0 group-hover:opacity-100 p-1 rounded hover:bg-zinc-200 dark:hover:bg-zinc-700 transition-opacity"
+            >
+              <MoreHorizontal className="h-3 w-3" />
+            </button>
+
+            <AnimatePresence>
+              {showMenu && (
+                <motion.div
+                  initial={{ opacity: 0, scale: 0.95 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.95 }}
+                  className="absolute right-0 top-full mt-1 w-36 rounded-lg border border-zinc-200 bg-white py-1 shadow-lg dark:border-zinc-800 dark:bg-zinc-900 z-[100]"
+                >
+                  <button
+                    onClick={handleUse}
+                    className="w-full px-3 py-1.5 text-left text-xs hover:bg-zinc-100 dark:hover:bg-zinc-800 flex items-center gap-2"
+                  >
+                    <Copy className="h-3 w-3" />
+                    Use Template
+                  </button>
+                  <button
+                    onClick={handleEdit}
+                    className="w-full px-3 py-1.5 text-left text-xs hover:bg-zinc-100 dark:hover:bg-zinc-800 flex items-center gap-2"
+                  >
+                    <Edit3 className="h-3 w-3" />
+                    Edit
+                  </button>
+                  <button
+                    onClick={handleRename}
+                    className="w-full px-3 py-1.5 text-left text-xs hover:bg-zinc-100 dark:hover:bg-zinc-800"
+                  >
+                    Rename
+                  </button>
+                  <button
+                    onClick={handleDelete}
+                    className="w-full px-3 py-1.5 text-left text-xs text-red-600 hover:bg-zinc-100 dark:hover:bg-zinc-800 flex items-center gap-2"
+                  >
+                    <Trash2 className="h-3 w-3" />
+                    Delete
+                  </button>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { Sun, Moon } from "lucide-react";
+
+export default function ThemeToggle({ theme, setTheme }) {
+  return (
+    <button
+      className="inline-flex items-center gap-2 rounded-full border border-zinc-200 bg-white px-2.5 py-1.5 text-sm hover:bg-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:border-zinc-800 dark:bg-zinc-950 dark:hover:bg-zinc-800"
+      onClick={() => setTheme((t) => (t === "dark" ? "light" : "dark"))}
+      aria-label="Toggle theme"
+      title="Toggle theme"
+    >
+      {theme === "dark" ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+      <span className="hidden sm:inline">{theme === "dark" ? "Light" : "Dark"}</span>
+    </button>
+  );
+}

--- a/frontend/src/components/canvas.tsx
+++ b/frontend/src/components/canvas.tsx
@@ -8,18 +8,14 @@ export function Canvas({ projectId }: CanvasProps) {
   return (
     <div className="flex-1 flex flex-col bg-gray-50">
       {/* Header */}
-      <div className="border-b border-gray-200 bg-white px-6 py-4">
-        <div className="flex items-center justify-between">
-          <div>
-            <h1 className="text-lg font-semibold text-gray-900">Project Canvas</h1>
-            <p className="text-sm text-gray-500">Project ID: {projectId}</p>
-          </div>
+      <div className="border-b border-gray-200 px-6 py-4">
+        <div className="flex items-center justify-end">
           <div className="flex items-center gap-2">
             <button className="rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-500">
               Export
             </button>
             <button className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-semibold text-gray-900 hover:bg-gray-50">
-              Share
+              Publish
             </button>
           </div>
         </div>
@@ -53,22 +49,6 @@ export function Canvas({ projectId }: CanvasProps) {
               <li>• Interactive workflows</li>
               <li>• Real-time collaboration features</li>
             </ul>
-            <div className="mt-6">
-              <button
-                type="button"
-                className="inline-flex items-center rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-500"
-              >
-                <svg
-                  className="-ml-0.5 mr-1.5 h-5 w-5"
-                  viewBox="0 0 20 20"
-                  fill="currentColor"
-                  aria-hidden="true"
-                >
-                  <path d="M10.75 4.75a.75.75 0 00-1.5 0v4.5h-4.5a.75.75 0 000 1.5h4.5v4.5a.75.75 0 001.5 0v-4.5h4.5a.75.75 0 000-1.5h-4.5v-4.5z" />
-                </svg>
-                Create First Element
-              </button>
-            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/canvas.tsx
+++ b/frontend/src/components/canvas.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+interface CanvasProps {
+  projectId: string
+}
+
+export function Canvas({ projectId }: CanvasProps) {
+  return (
+    <div className="flex-1 flex flex-col bg-gray-50">
+      {/* Header */}
+      <div className="border-b border-gray-200 bg-white px-6 py-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-lg font-semibold text-gray-900">Project Canvas</h1>
+            <p className="text-sm text-gray-500">Project ID: {projectId}</p>
+          </div>
+          <div className="flex items-center gap-2">
+            <button className="rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-500">
+              Export
+            </button>
+            <button className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-semibold text-gray-900 hover:bg-gray-50">
+              Share
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Canvas Area */}
+      <div className="flex-1 p-6">
+        <div className="flex h-full items-center justify-center rounded-lg border-2 border-dashed border-gray-300 bg-white">
+          <div className="text-center">
+            <svg
+              className="mx-auto h-12 w-12 text-gray-400"
+              stroke="currentColor"
+              fill="none"
+              viewBox="0 0 48 48"
+              aria-hidden="true"
+            >
+              <path
+                d="M28 8H12a4 4 0 00-4 4v20m32-12v8m0 0v8a4 4 0 01-4 4H12a4 4 0 01-4-4v-4m32-4l-3.172-3.172a4 4 0 00-5.656 0L28 28M8 32l9.172-9.172a4 4 0 015.656 0L28 28m0 0l4 4m4-24h8m-4-4v8m-12 4h.02"
+                strokeWidth={2}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+            <h3 className="mt-2 text-sm font-semibold text-gray-900">Canvas Area</h3>
+            <p className="mt-1 text-sm text-gray-500">
+              This is a placeholder for the project canvas. In the future, this will display:
+            </p>
+            <ul className="mt-2 text-sm text-gray-500 space-y-1">
+              <li>• Visual project diagrams</li>
+              <li>• Code structure visualization</li>
+              <li>• Interactive workflows</li>
+              <li>• Real-time collaboration features</li>
+            </ul>
+            <div className="mt-6">
+              <button
+                type="button"
+                className="inline-flex items-center rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-500"
+              >
+                <svg
+                  className="-ml-0.5 mr-1.5 h-5 w-5"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <path d="M10.75 4.75a.75.75 0 00-1.5 0v4.5h-4.5a.75.75 0 000 1.5h4.5v4.5a.75.75 0 001.5 0v-4.5h4.5a.75.75 0 000-1.5h-4.5v-4.5z" />
+                </svg>
+                Create First Element
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/chat-interface.tsx
+++ b/frontend/src/components/chat-interface.tsx
@@ -1,0 +1,127 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { useSearchParams } from "next/navigation"
+import ChatPane from "./ChatPane"
+
+interface ChatInterfaceProps {
+  projectId: string
+}
+
+export function ChatInterface({ projectId }: ChatInterfaceProps) {
+  const searchParams = useSearchParams()
+  const initialPrompt = searchParams.get("prompt")
+  
+  const [conversation, setConversation] = useState(() => {
+    const now = new Date().toISOString()
+    const messages = []
+    
+    // If there's an initial prompt, add it as the first user message
+    if (initialPrompt) {
+      messages.push({
+        id: crypto.randomUUID(),
+        role: "user",
+        content: initialPrompt,
+        createdAt: now
+      })
+      
+      // Add hardcoded AI response
+      // TODO: Replace with actual AI API call
+      messages.push({
+        id: crypto.randomUUID(),
+        role: "assistant", 
+        content: "I understand you want to work on: \"" + initialPrompt + "\". I'm here to help you build this step by step. What would you like to start with first?",
+        createdAt: now
+      })
+    }
+    
+    return {
+      id: projectId,
+      title: initialPrompt ? `Project: ${initialPrompt.slice(0, 50)}...` : "New Project",
+      updatedAt: now,
+      messageCount: messages.length,
+      preview: initialPrompt || "New project chat",
+      pinned: false,
+      folder: "Projects",
+      messages
+    }
+  })
+
+  const [isThinking, setIsThinking] = useState(false)
+
+  const handleSendMessage = async (content: string) => {
+    if (!content.trim()) return
+
+    const now = new Date().toISOString()
+    const userMessage = {
+      id: crypto.randomUUID(),
+      role: "user" as const,
+      content,
+      createdAt: now
+    }
+
+    // Add user message
+    setConversation(prev => ({
+      ...prev,
+      messages: [...prev.messages, userMessage],
+      updatedAt: now,
+      messageCount: prev.messageCount + 1,
+      preview: content.slice(0, 80)
+    }))
+
+    // Show thinking state
+    setIsThinking(true)
+
+    // Simulate AI response delay
+    setTimeout(() => {
+      // TODO: Replace with actual AI API call
+      const aiResponse = {
+        id: crypto.randomUUID(),
+        role: "assistant" as const,
+        content: "Thanks for your message! I'm a hardcoded response for now. In the future, I'll be replaced with actual AI API calls to provide intelligent responses to help you build your project.",
+        createdAt: new Date().toISOString()
+      }
+
+      setConversation(prev => ({
+        ...prev,
+        messages: [...prev.messages, aiResponse],
+        updatedAt: aiResponse.createdAt,
+        messageCount: prev.messageCount + 1,
+        preview: aiResponse.content.slice(0, 80)
+      }))
+
+      setIsThinking(false)
+    }, 2000)
+  }
+
+  const handleEditMessage = (messageId: string, newContent: string) => {
+    const now = new Date().toISOString()
+    setConversation(prev => ({
+      ...prev,
+      messages: prev.messages.map(msg => 
+        msg.id === messageId 
+          ? { ...msg, content: newContent, editedAt: now }
+          : msg
+      ),
+      updatedAt: now
+    }))
+  }
+
+  const handleResendMessage = (messageId: string) => {
+    const message = conversation.messages.find(msg => msg.id === messageId)
+    if (message) {
+      handleSendMessage(message.content)
+    }
+  }
+
+  return (
+    <ChatPane
+      conversation={conversation}
+      onSend={handleSendMessage}
+      onEditMessage={handleEditMessage}
+      onResendMessage={handleResendMessage}
+      isThinking={isThinking}
+      onPauseThinking={() => setIsThinking(false)}
+    />
+  )
+}

--- a/frontend/src/components/mockData.js
+++ b/frontend/src/components/mockData.js
@@ -1,0 +1,241 @@
+import { makeId } from "./utils"
+
+export const INITIAL_CONVERSATIONS = [
+  {
+    id: "c1",
+    title: "Marketing plan for launch",
+    updatedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+    messageCount: 12,
+    preview: "Drafting a 4-week GTM plan with channels, KPIs, and budget...",
+    pinned: true,
+    folder: "Work Projects",
+    messages: [
+      {
+        id: makeId("m"),
+        role: "user",
+        content: "Draft a 4-week GTM plan.",
+        createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+      },
+      {
+        id: makeId("m"),
+        role: "assistant",
+        content: "Sure — phases, owners, risks, and KPIs coming up.",
+        createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000 + 60000).toISOString(),
+      },
+    ],
+  },
+  {
+    id: "c2",
+    title: "Research: vector databases vs RAG",
+    updatedAt: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+    messageCount: 22,
+    preview: "Compare pgvector, Milvus, and Weaviate. Cost + latency notes...",
+    pinned: false,
+    folder: "Code Reviews",
+    messages: [],
+  },
+  {
+    id: "c3",
+    title: "Trip checklist – Paris with family",
+    updatedAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
+    messageCount: 9,
+    preview: "Packing list, museum tickets, metro pass options, and cafés...",
+    pinned: false,
+    folder: "Personal",
+    messages: [],
+  },
+  {
+    id: "c4",
+    title: "Refactor prompt templates for support",
+    updatedAt: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+    messageCount: 17,
+    preview: "Turn macros into reusable templates with variables and guardrails...",
+    pinned: true,
+    folder: "Work Projects",
+    messages: [],
+  },
+  {
+    id: "c5",
+    title: "Bug triage notes",
+    updatedAt: new Date(Date.now() - 4 * 60 * 60 * 1000).toISOString(),
+    messageCount: 6,
+    preview: "Priorities: login rate limit, streaming flicker, retry policy...",
+    pinned: false,
+    folder: "Work Projects",
+    messages: [],
+  },
+  {
+    id: "c6",
+    title: "AI agent: inbox clean-up flow",
+    updatedAt: new Date(Date.now() - 35 * 60 * 1000).toISOString(),
+    messageCount: 31,
+    preview: "Classifier → summarize → bulk actions with undo and logs...",
+    pinned: false,
+    folder: "Work Projects",
+    messages: [],
+  },
+  {
+    id: "c7",
+    title: "Weekly review – personal goals",
+    updatedAt: new Date(Date.now() - 6 * 60 * 60 * 1000).toISOString(),
+    messageCount: 8,
+    preview: "Sleep routine, gym cadence, reading list, dopamine detox...",
+    pinned: false,
+    folder: "Personal",
+    messages: [],
+  },
+  {
+    id: "c8",
+    title: "Code review: message composer",
+    updatedAt: new Date(Date.now() - 50 * 60 * 1000).toISOString(),
+    messageCount: 14,
+    preview: "Edge cases: IME input, paste images, drag-n-drop, retries...",
+    pinned: false,
+    folder: "Code Reviews",
+    messages: [],
+  },
+  {
+    id: "c9",
+    title: "LLM evals – rubric + dataset",
+    updatedAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+    messageCount: 40,
+    preview: "BLEU vs human eval, task matrix, hallucination checks...",
+    pinned: false,
+    folder: "Work Projects",
+    messages: [],
+  },
+  {
+    id: "c10",
+    title: "Prompt library – onboarding",
+    updatedAt: new Date(Date.now() - 15 * 60 * 1000).toISOString(),
+    messageCount: 11,
+    preview: "Create intro prompts for HR, IT, and support with guardrails...",
+    pinned: false,
+    folder: "Work Projects",
+    messages: [],
+  },
+  {
+    id: "c11",
+    title: "Grocery budgeting – monthly",
+    updatedAt: new Date(Date.now() - 9 * 24 * 60 * 60 * 1000).toISOString(),
+    messageCount: 5,
+    preview: "Track cost per meal, reduce waste, and plan bulk buys...",
+    pinned: false,
+    folder: "Personal",
+    messages: [],
+  },
+]
+
+export const INITIAL_TEMPLATES = [
+  {
+    id: "t1",
+    name: "Bug Report",
+    content: `**Bug Report**
+
+**Description:**
+Brief description of the issue
+
+**Steps to Reproduce:**
+1. Step one
+2. Step two
+3. Step three
+
+**Expected Behavior:**
+What should happen
+
+**Actual Behavior:**
+What actually happens
+
+**Environment:**
+- Browser/OS:
+- Version:
+- Additional context:`,
+    snippet: "Structured bug report template with steps to reproduce...",
+    createdAt: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+    updatedAt: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    id: "t2",
+    name: "Daily Standup",
+    content: `**Daily Standup Update**
+
+**Yesterday:**
+- Completed task A
+- Made progress on task B
+
+**Today:**
+- Plan to work on task C
+- Continue with task B
+
+**Blockers:**
+- None / List any blockers here
+
+**Notes:**
+Any additional context or updates`,
+    snippet: "Daily standup format with yesterday, today, and blockers...",
+    createdAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+    updatedAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    id: "t3",
+    name: "Code Review",
+    content: `**Code Review Checklist**
+
+**Scope:**
+What changes are being reviewed
+
+**Key Areas to Focus:**
+- Logic correctness
+- Performance implications
+- Security considerations
+- Test coverage
+
+**Questions:**
+- Any specific concerns?
+- Performance impact?
+- Breaking changes?
+
+**Testing:**
+- Unit tests added/updated?
+- Manual testing completed?`,
+    snippet: "Comprehensive code review checklist and questions...",
+    createdAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+    updatedAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    id: "t4",
+    name: "Meeting Notes",
+    content: `**Meeting Notes - [Meeting Title]**
+
+**Date:** [Date]
+**Attendees:** [List attendees]
+
+**Agenda:**
+1. Topic 1
+2. Topic 2
+3. Topic 3
+
+**Key Decisions:**
+- Decision 1
+- Decision 2
+
+**Action Items:**
+- [ ] Task 1 - @person - Due: [date]
+- [ ] Task 2 - @person - Due: [date]
+
+**Next Steps:**
+What happens next
+
+**Notes:**
+Additional context and discussion points`,
+    snippet: "Meeting notes template with agenda, decisions, and action items...",
+    createdAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
+    updatedAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+]
+
+export const INITIAL_FOLDERS = [
+  { id: "f1", name: "Work Projects" },
+  { id: "f2", name: "Personal" },
+  { id: "f3", name: "Code Reviews" },
+]

--- a/frontend/src/components/ui/animated-ai-input.tsx
+++ b/frontend/src/components/ui/animated-ai-input.tsx
@@ -1,11 +1,13 @@
 "use client"
 
 import { useState } from "react"
+import { useRouter } from "next/navigation"
 import { useAutoResizeTextarea } from "../../hooks/use-auto-resize-textarea"
 import { Button } from "./button"
 
 export function AnimatedAIInput() {
   const [value, setValue] = useState("")
+  const router = useRouter()
   const { textareaRef, adjustHeight } = useAutoResizeTextarea({
     minHeight: 120,
     maxHeight: 400,
@@ -20,11 +22,20 @@ export function AnimatedAIInput() {
     "GPT-4-1",
   ]
 
+  const handleSubmit = () => {
+    if (!value.trim()) return
+    
+    // Generate unique project ID
+    const projectId = crypto.randomUUID()
+    
+    // Navigate to project page with initial prompt
+    router.push(`/projects/${projectId}?prompt=${encodeURIComponent(value)}`)
+  }
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault()
-      // Handle send message
-      console.log("Sending message:", value)
+      handleSubmit()
     }
   }
 
@@ -72,6 +83,7 @@ export function AnimatedAIInput() {
               size="sm"
               className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2"
               disabled={!value.trim()}
+              onClick={handleSubmit}
             >
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />

--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import * as React from "react"
+import * as PopoverPrimitive from "@radix-ui/react-popover"
+
+import { cn } from "@/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }

--- a/frontend/src/components/utils.js
+++ b/frontend/src/components/utils.js
@@ -1,0 +1,30 @@
+export const cls = (...c) => c.filter(Boolean).join(" ");
+
+export function timeAgo(date) {
+  const d = typeof date === "string" ? new Date(date) : date;
+  const now = new Date();
+  const sec = Math.max(1, Math.floor((now - d) / 1000));
+  const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+  const ranges = [
+    [60, "seconds"], [3600, "minutes"], [86400, "hours"],
+    [604800, "days"], [2629800, "weeks"], [31557600, "months"],
+  ];
+  let unit = "years";
+  let value = -Math.floor(sec / 31557600);
+  for (const [limit, u] of ranges) {
+    if (sec < limit) {
+      unit = u;
+      const div =
+        unit === "seconds" ? 1 :
+        limit / (unit === "minutes" ? 60 :
+        unit === "hours" ? 3600 :
+        unit === "days" ? 86400 :
+        unit === "weeks" ? 604800 : 2629800);
+      value = -Math.floor(sec / div);
+      break;
+    }
+  }
+  return rtf.format(value, /** @type {Intl.RelativeTimeFormatUnit} */ (unit));
+}
+
+export const makeId = (p) => `${p}${Math.random().toString(36).slice(2, 10)}`;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Introduces the Builder UI with a split chat + canvas workspace. You can start a project from the home prompt, continue the conversation, and view outputs on the canvas.

- **New Features**
  - Projects page at /projects/[id] with a left chat panel and right canvas.
  - Home prompt now creates a new project ID and routes with ?prompt=..., including Enter-to-submit.
  - Chat interface: composer, actions popover, messages, header, and sidebar with pinned/recent, folders, templates, search, settings, and theme toggle (saved in localStorage).
  - Canvas scaffold with Export and Publish actions.
  - Popover UI wrapper built on Radix; seed data and placeholder responses for now.

- **Dependencies**
  - Loosened @radix-ui/react-popover to ^1.1.4.

<!-- End of auto-generated description by cubic. -->

