### PR TITLE
Move away from browser dialog

### DIFF
--- a/frontend/src/components/canvas.tsx
+++ b/frontend/src/components/canvas.tsx
@@ -4,7 +4,7 @@ import { WorkflowCanvas } from './workflow/workflow-canvas';
 import { AnimatedCoral } from './animated-coral';
 import { useState } from 'react'
 import type { Project } from '@/contexts/AuthContext';
-import { WorkflowQueryDialog } from './ui/workflow-query-dialog';
+import { RunQueryAlertDialog } from './ui/run-query-alert-dialog';
 
 interface CanvasProps {
   project: Project
@@ -130,7 +130,7 @@ export function Canvas({ project }: CanvasProps) {
       </div>
 
       {/* Query Dialog */}
-      <WorkflowQueryDialog
+      <RunQueryAlertDialog
         open={showQueryDialog}
         onOpenChange={setShowQueryDialog}
         onSubmit={handleQuerySubmit}

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,146 @@
+"use client"
+
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+
+const AlertDialog = AlertDialogPrimitive.Root
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return <AlertDialogPrimitive.Portal {...props} />
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        className={cn(
+          "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 rounded-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col space-y-2 text-center sm:text-left",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      className={cn("text-lg font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      className={cn("text-sm text-gray-600", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action
+      className={cn(
+        "inline-flex h-10 items-center justify-center rounded-md bg-gray-900 px-4 py-2 text-sm font-semibold text-white hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(
+        "mt-2 inline-flex h-10 items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-900 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 disabled:opacity-50 sm:mt-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/frontend/src/components/ui/run-query-alert-dialog.tsx
+++ b/frontend/src/components/ui/run-query-alert-dialog.tsx
@@ -1,0 +1,86 @@
+"use client"
+
+import * as React from "react"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "./alert-dialog"
+import { Input } from "./input"
+
+interface RunQueryAlertDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSubmit: (query: string) => void
+}
+
+export function RunQueryAlertDialog({
+  open,
+  onOpenChange,
+  onSubmit
+}: RunQueryAlertDialogProps) {
+  const [query, setQuery] = React.useState("")
+
+  const handleSubmit = () => {
+    if (query.trim()) {
+      onSubmit(query.trim())
+      setQuery("")
+      onOpenChange(false)
+    }
+  }
+
+  const handleCancel = () => {
+    setQuery("")
+    onOpenChange(false)
+  }
+
+  React.useEffect(() => {
+    if (open) {
+      setQuery("")
+    }
+  }, [open])
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent className="sm:max-w-md">
+        <AlertDialogHeader>
+          <AlertDialogTitle>Run Workflow</AlertDialogTitle>
+          <AlertDialogDescription>
+            Enter a query to run with this workflow:
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <div className="grid gap-4 py-4">
+          <Input
+            id="query"
+            placeholder="Enter your query..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            autoFocus
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && query.trim()) {
+                handleSubmit()
+              }
+            }}
+          />
+        </div>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={handleCancel}>
+            Cancel
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleSubmit}
+            disabled={!query.trim()}
+            className={!query.trim() ? "opacity-50 cursor-not-allowed" : ""}
+          >
+            Run
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}


### PR DESCRIPTION
Move away from browser dialog
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced the native browser dialog with a Radix-based alert dialog for running workflow queries. This adds a reusable dialog and improves UX, styling, and control.

- **Refactors**
  - Added ui/alert-dialog.tsx built on @radix-ui/react-alert-dialog.
  - Added RunQueryAlertDialog with input, validation, and keyboard submit.
  - Updated Canvas to use RunQueryAlertDialog instead of WorkflowQueryDialog.

<!-- End of auto-generated description by cubic. -->

