### PR TITLE
Add ci/cd for the factory

### DIFF
--- a/.github/workflows/deploy-factory.yml
+++ b/.github/workflows/deploy-factory.yml
@@ -1,0 +1,46 @@
+name: Deploy Factory to Google Cloud Run
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "coral_factory/**"
+
+jobs:
+  deploy:
+    name: Build & Deploy Factory
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Google Artifact Registry
+        run: gcloud auth configure-docker gcr.io
+
+      - name: Build Docker Image
+        working-directory: ./coral_factory
+        run: |
+          docker build --platform linux/amd64 -t gcr.io/reefs-c1adb/coral-factory .
+
+      - name: Push Docker Image
+        run: |
+          docker push gcr.io/reefs-c1adb/coral-factory
+
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run deploy coral-factory \
+            --image gcr.io/reefs-c1adb/coral-factory \
+            --platform managed \
+            --region europe-west1 \
+            --allow-unauthenticated \
+            --project reefs-c1adb


### PR DESCRIPTION
Add ci/cd for the factory - deploy to Google Cloud Run
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Set up CI/CD to build and deploy Coral Factory to Google Cloud Run. Added a Docker image and updated the app; removed the legacy coral-server code.

- **New Features**
  - GitHub Actions workflow deploys on push to main for coral_factory/.
  - Builds and pushes gcr.io/reefs-c1adb/coral-factory, then deploys to Cloud Run.
  - New Dockerfile (Python 3.12, uvicorn on port 8001) with FACTORY_BEARER_TOKEN env support.

- **Refactors**
  - FastAPI app now uses factory.builder WorkflowConfig and factory.runner WorkflowRunner.
  - Auth env var renamed to FACTORY_BEARER_TOKEN; .env support added.
  - Simplified README.
  - Removed coral_factory/coral-server (Kotlin server, Gradle files, examples, old CI).

<!-- End of auto-generated description by cubic. -->

