### PR TITLE
Update factory port

### DIFF
--- a/coral_factory/Dockerfile
+++ b/coral_factory/Dockerfile
@@ -25,6 +25,6 @@ EXPOSE 8001
 # Default auth token can be overridden at runtime
 ENV FACTORY_BEARER_TOKEN=bearer-token-2024
 
-CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8001"]
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080"]
 
 


### PR DESCRIPTION
Update factory port
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switch factory service to port 8080. Updates the Dockerfile to run uvicorn on 8080 to match our deployment port.

<!-- End of auto-generated description by cubic. -->

