### PR TITLE
Fix heart dark mode

### DIFF
--- a/frontend/src/components/cta-section.tsx
+++ b/frontend/src/components/cta-section.tsx
@@ -31,7 +31,11 @@ export default function CTASection() {
               </div>
               <div className="text-muted-foreground text-sm font-medium leading-[18px] font-sans flex items-center gap-1">
                 Made with{" "}
-                <img src="/heart.svg" alt="heart" className="w-4 h-4 inline" />{" "}
+                <img
+                  src="/heart.svg"
+                  alt="heart"
+                  className="w-4 h-4 inline filter dark:invert"
+                />{" "}
                 in New York
               </div>
             </div>


### PR DESCRIPTION
Before:
<img width="213" height="29" alt="image" src="https://github.com/user-attachments/assets/10ffef95-0601-49de-a077-91178c081e9f" />

After:
<img width="194" height="27" alt="image" src="https://github.com/user-attachments/assets/6c2ff444-65fd-41c0-b86d-9caf931c3bb2" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the heart icon in the CTA section for dark mode by adding a dark invert filter to the SVG so it stays visible and matches the theme.

<!-- End of auto-generated description by cubic. -->

